### PR TITLE
Add frontend unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/app.js
+++ b/app.js
@@ -16,6 +16,10 @@ const DATE_KEYS = ['Buchungstag', 'Buchungsdatum', 'Datum', 'Wertstellung', 'Wer
 
 // Render table in the DOM
 function renderTable(data) {
+  if (typeof document === 'undefined') {
+    throw new Error('renderTable requires a DOM environment');
+  }
+
   const container = document.getElementById('tableContainer');
   if (!data.length) {
     container.innerHTML = '';
@@ -140,97 +144,116 @@ function anonymize(data) {
   });
 }
 
-const fileInput = document.getElementById('csvFile');
-const anonymizeBtn = document.getElementById('anonymizeBtn');
-// Button to trigger categorization; may not exist if HTML hasn't been updated yet
-const categorizeBtn = document.getElementById('categorizeBtn');
 let csvData = [];
 
-fileInput.addEventListener('change', (event) => {
-  const files = Array.from(event.target.files || []);
-  if (!files.length) return;
+if (typeof document !== 'undefined') {
+  const fileInput = document.getElementById('csvFile');
+  const anonymizeBtn = document.getElementById('anonymizeBtn');
+  // Button to trigger categorization; may not exist if HTML hasn't been updated yet
+  const categorizeBtn = document.getElementById('categorizeBtn');
 
-  Promise.all(files.map((file) => readFileAsText(file)))
-    .then((contents) => {
-      const parsed = contents.flatMap((text) => parseCSV(text));
-      csvData = mergeTransactions(csvData, parsed);
-      renderTable(csvData);
-      anonymizeBtn.disabled = csvData.length === 0;
-      // Disable categorize button until data has been anonymized
-      if (categorizeBtn) categorizeBtn.disabled = true;
-    })
-    .catch((err) => {
-      console.error('Fehler beim Lesen der Dateien:', err);
-      alert('Fehler beim Lesen der Dateien: ' + err.message);
-    })
-    .finally(() => {
-      // Allow selecting the same file again by resetting the input value
-      event.target.value = '';
+  if (fileInput) {
+    fileInput.addEventListener('change', (event) => {
+      const files = Array.from(event.target.files || []);
+      if (!files.length) return;
+
+      Promise.all(files.map((file) => readFileAsText(file)))
+        .then((contents) => {
+          const parsed = contents.flatMap((text) => parseCSV(text));
+          csvData = mergeTransactions(csvData, parsed);
+          renderTable(csvData);
+          if (anonymizeBtn) anonymizeBtn.disabled = csvData.length === 0;
+          // Disable categorize button until data has been anonymized
+          if (categorizeBtn) categorizeBtn.disabled = true;
+        })
+        .catch((err) => {
+          console.error('Fehler beim Lesen der Dateien:', err);
+          alert('Fehler beim Lesen der Dateien: ' + err.message);
+        })
+        .finally(() => {
+          // Allow selecting the same file again by resetting the input value
+          event.target.value = '';
+        });
     });
-});
+  }
 
-// Anonymize data only; enables categorize button after anonymization
-anonymizeBtn.addEventListener('click', () => {
-  csvData = anonymize(csvData);
-  renderTable(csvData);
-  // Enable categorize button now that data is anonymized
-  if (categorizeBtn) categorizeBtn.disabled = false;
-});
+  // Anonymize data only; enables categorize button after anonymization
+  if (anonymizeBtn) {
+    anonymizeBtn.addEventListener('click', () => {
+      csvData = anonymize(csvData);
+      renderTable(csvData);
+      // Enable categorize button now that data is anonymized
+      if (categorizeBtn) categorizeBtn.disabled = false;
+    });
+  }
 
-// Send anonymized data to backend for categorization when categorize button is clicked
-if (categorizeBtn) {
-  categorizeBtn.addEventListener('click', () => {
-    const transactions = csvData.map((row) => row['Verwendungszweck']);
-    fetch('https://umsatz-api.onrender.com/categorize', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ transactions }),
-    })
-      .then((resp) => {
-        if (!resp.ok) {
-          return resp.json().then((e) => {
-            throw new Error(e.error || resp.statusText);
-          });
-        }
-        return resp.json();
+  // Send anonymized data to backend for categorization when categorize button is clicked
+  if (categorizeBtn) {
+    categorizeBtn.addEventListener('click', () => {
+      const transactions = csvData.map((row) => row['Verwendungszweck']);
+      fetch('https://umsatz-api.onrender.com/categorize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ transactions }),
       })
-      .then((data) => {
-        let categories = data.categories || [];
-        // If categories is not an array, attempt to parse or split it
-        if (!Array.isArray(categories)) {
-          try {
-            categories = JSON.parse(categories);
-          } catch {
-            categories = String(categories)
-              .replace(/^[\[{]*|[\]}]*$/g, '')
-              .split(',')
-              .map((s) => s.replace(/"/g, '').trim())
-              .filter(Boolean);
+        .then((resp) => {
+          if (!resp.ok) {
+            return resp.json().then((e) => {
+              throw new Error(e.error || resp.statusText);
+            });
           }
-        }
-        // If categories is an array with one string containing a JSON array, parse it
-        if (Array.isArray(categories) && categories.length === 1 && typeof categories[0] === 'string') {
-          const catStr = categories[0].trim();
-          try {
-            categories = JSON.parse(catStr);
-          } catch {
-            categories = catStr
-              .replace(/^[\[{]*|[\]}]*$/g, '')
-              .split(',')
-              .map((s) => s.replace(/"/g, '').trim())
-              .filter(Boolean);
+          return resp.json();
+        })
+        .then((data) => {
+          let categories = data.categories || [];
+          // If categories is not an array, attempt to parse or split it
+          if (!Array.isArray(categories)) {
+            try {
+              categories = JSON.parse(categories);
+            } catch {
+              categories = String(categories)
+                .replace(/^[\[{]*|[\]}]*$/g, '')
+                .split(',')
+                .map((s) => s.replace(/"/g, '').trim())
+                .filter(Boolean);
+            }
           }
-        }
-        // Assign categories to each row
-        csvData = csvData.map((row, idx) => ({
-          ...row,
-          Kategorie: categories[idx] || '',
-        }));
-        renderTable(csvData);
-      })
-      .catch((err) => {
-        console.error('Fehler bei der Kategorisierung:', err);
-        alert('Fehler bei der Kategorisierung: ' + err.message);
-      });
-  });
+          // If categories is an array with one string containing a JSON array, parse it
+          if (Array.isArray(categories) && categories.length === 1 && typeof categories[0] === 'string') {
+            const catStr = categories[0].trim();
+            try {
+              categories = JSON.parse(catStr);
+            } catch {
+              categories = catStr
+                .replace(/^[\[{]*|[\]}]*$/g, '')
+                .split(',')
+                .map((s) => s.replace(/"/g, '').trim())
+                .filter(Boolean);
+            }
+          }
+          // Assign categories to each row
+          csvData = csvData.map((row, idx) => ({
+            ...row,
+            Kategorie: categories[idx] || '',
+          }));
+          renderTable(csvData);
+        })
+        .catch((err) => {
+          console.error('Fehler bei der Kategorisierung:', err);
+          alert('Fehler bei der Kategorisierung: ' + err.message);
+        });
+    });
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    parseCSV,
+    renderTable,
+    parseDateString,
+    getDateValue,
+    mergeTransactions,
+    readFileAsText,
+    anonymize,
+  };
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/server.js
+++ b/server.js
@@ -10,9 +10,13 @@ app.use(cors());
 app.use(bodyParser.json());
 
 // Initialize OpenAI client using v4 API
-const openai = new OpenAI({
+let openaiClient = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
 });
+
+const setOpenAIClient = (client) => {
+  openaiClient = client;
+};
 
 // POST route to categorize transactions
 app.post('/categorize', async (req, res) => {
@@ -39,7 +43,7 @@ app.post('/categorize', async (req, res) => {
     };
 
     // Call OpenAI chat completion with gpt-3.5-turbo model
-    const completion = await openai.chat.completions.create({
+    const completion = await openaiClient.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages: [systemMessage, userMessage],
       max_tokens: 200,
@@ -79,6 +83,10 @@ app.get('/', (_req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.listen(port, () => {
-  console.log(`Server running on port ${port}`);
-});
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}
+
+module.exports = { app, setOpenAIClient };

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -1,0 +1,90 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  parseCSV,
+  mergeTransactions,
+  anonymize,
+  parseDateString,
+  getDateValue,
+} = require('../app');
+
+test('parseCSV converts semicolon separated text into objects', () => {
+  const text = 'A;B;C\n1;2;3\n4;5;6';
+  const rows = parseCSV(text);
+
+  assert.deepStrictEqual(rows, [
+    { A: '1', B: '2', C: '3' },
+    { A: '4', B: '5', C: '6' },
+  ]);
+});
+
+test('mergeTransactions sorts rows by detected date descending', () => {
+  const existing = [
+    { Buchungsdatum: '01.01.2023', Betrag: '10' },
+    { Datum: '2022-12-30', Betrag: '20' },
+  ];
+  const incoming = [
+    { Wertstellung: '05.01.2023', Betrag: '30' },
+    { Datum: '2022-12-30', Betrag: '40' },
+  ];
+
+  const merged = mergeTransactions(existing, incoming);
+
+  assert.deepStrictEqual(merged, [
+    { Wertstellung: '05.01.2023', Betrag: '30' },
+    { Buchungsdatum: '01.01.2023', Betrag: '10' },
+    { Datum: '2022-12-30', Betrag: '20' },
+    { Datum: '2022-12-30', Betrag: '40' },
+  ]);
+});
+
+test('mergeTransactions keeps original order when date comparison ties', () => {
+  const rows = [
+    { Buchungsdatum: '01.02.2023', Betrag: '10' },
+    { Buchungsdatum: '01.02.2023', Betrag: '20' },
+  ];
+
+  const merged = mergeTransactions([], rows);
+
+  assert.deepStrictEqual(merged, rows);
+});
+
+test('anonymize masks long numbers and simple names in Verwendungszweck', () => {
+  const rows = [
+    { Verwendungszweck: 'Überweisung an Max Mustermann 123456789' },
+    { Verwendungszweck: 'Kartenzahlung Supermarkt 9876' },
+  ];
+
+  const anonymized = anonymize(rows);
+
+  assert.deepStrictEqual(anonymized, [
+    { Verwendungszweck: 'Überweisung an XXX XXX ***' },
+    { Verwendungszweck: 'XXX XXX ***' },
+  ]);
+});
+
+test('parseDateString handles german and iso formats and ignores invalid', () => {
+  const german = parseDateString('15.03.2024');
+  const iso = parseDateString('2024-03-16');
+  const invalid = parseDateString('not a date');
+
+  assert.ok(german instanceof Date && !Number.isNaN(german.getTime()));
+  assert.strictEqual(german.getFullYear(), 2024);
+  assert.ok(iso instanceof Date && !Number.isNaN(iso.getTime()));
+  assert.strictEqual(iso.getMonth(), 2);
+  assert.strictEqual(invalid, null);
+});
+
+test('getDateValue returns the first parsable date from preferred keys', () => {
+  const row = {
+    Beschreibung: 'Test',
+    Datum: '17.03.2024',
+    Wertstellung: '2024-03-15',
+  };
+
+  const value = getDateValue(row);
+
+  const expected = parseDateString('17.03.2024').getTime();
+  assert.strictEqual(value, expected);
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,161 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || 'test-key';
+
+const { app, setOpenAIClient } = require('../server');
+
+const startServer = () =>
+  new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address();
+      resolve({ server, port });
+    });
+  });
+
+const sendRequest = (port, { method, path, body }) =>
+  new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : undefined;
+    const request = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': data ? Buffer.byteLength(data) : 0,
+        },
+      },
+      (response) => {
+        let raw = '';
+        response.setEncoding('utf8');
+        response.on('data', (chunk) => {
+          raw += chunk;
+        });
+        response.on('end', () => {
+          let parsed;
+          try {
+            parsed = raw ? JSON.parse(raw) : {};
+          } catch (error) {
+            return reject(error);
+          }
+          resolve({ status: response.statusCode, body: parsed });
+        });
+      }
+    );
+
+    request.on('error', reject);
+
+    if (data) {
+      request.write(data);
+    }
+    request.end();
+  });
+
+test('categorize returns OpenAI JSON output as categories', async (t) => {
+  const mockClient = {
+    chat: {
+      completions: {
+        create: async () => ({
+          choices: [
+            {
+              message: { content: '["Essen", "Reisen"]' },
+            },
+          ],
+        }),
+      },
+    },
+  };
+
+  setOpenAIClient(mockClient);
+
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const response = await sendRequest(port, {
+    method: 'POST',
+    path: '/categorize',
+    body: { transactions: ['Supermarkt', 'Hotel'] },
+  });
+
+  assert.strictEqual(response.status, 200);
+  assert.deepStrictEqual(response.body, { categories: ['Essen', 'Reisen'] });
+});
+
+test('categorize falls back to parsing plain text responses', async (t) => {
+  const mockClient = {
+    chat: {
+      completions: {
+        create: async () => ({
+          choices: [
+            {
+              message: { content: 'Essen, Unterhaltung , Sonstiges' },
+            },
+          ],
+        }),
+      },
+    },
+  };
+
+  setOpenAIClient(mockClient);
+
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const response = await sendRequest(port, {
+    method: 'POST',
+    path: '/categorize',
+    body: { transactions: ['Pizza', 'Kino', '???'] },
+  });
+
+  assert.strictEqual(response.status, 200);
+  assert.deepStrictEqual(response.body, {
+    categories: ['Essen', 'Unterhaltung', 'Sonstiges'],
+  });
+});
+
+test('categorize validates the request payload', async (t) => {
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const response = await sendRequest(port, {
+    method: 'POST',
+    path: '/categorize',
+    body: { transactions: 'invalid' },
+  });
+
+  assert.strictEqual(response.status, 400);
+  assert.deepStrictEqual(response.body, {
+    error: 'transactions array required',
+  });
+});
+
+test('categorize surfaces OpenAI API errors', async (t) => {
+  const mockClient = {
+    chat: {
+      completions: {
+        create: async () => {
+          const error = new Error('Rate limited');
+          error.status = 429;
+          throw error;
+        },
+      },
+    },
+  };
+
+  setOpenAIClient(mockClient);
+
+  const { server, port } = await startServer();
+  t.after(() => server.close());
+
+  const response = await sendRequest(port, {
+    method: 'POST',
+    path: '/categorize',
+    body: { transactions: ['Flugticket'] },
+  });
+
+  assert.strictEqual(response.status, 429);
+  assert.deepStrictEqual(response.body, { error: 'Rate limited' });
+});


### PR DESCRIPTION
## Summary
- guard browser-only logic so the frontend script can be required from tests and export utility functions for reuse
- add a Node test suite covering CSV parsing, transaction ordering, anonymization, and date extraction helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3a682716083339c601268656bfede