### PR TITLE
Improve anonymization rules per transaction type

### DIFF
--- a/app.js
+++ b/app.js
@@ -129,18 +129,187 @@ function readFileAsText(file) {
   });
 }
 
-// Remove sensitive information from Verwendungszweck
+const TYPE_KEYS = ['Type', 'Typ', 'type', 'Umsatzart', 'Umsatztyp', 'Buchungstyp', 'Art'];
+const COMPANY_SUFFIXES = [
+  'gmbh',
+  'mbh',
+  'ag',
+  'kg',
+  'kgaa',
+  'ug',
+  'se',
+  'oy',
+  'oyj',
+  'ab',
+  'sarl',
+  'srl',
+  'spa',
+  'bv',
+  'nv',
+  'inc',
+  'llc',
+  'ltd',
+  'limited',
+  'company',
+  'co',
+  'sas',
+  'sa',
+  'plc',
+];
+const PARTNER_KEYS = [
+  'Zahlungspartner',
+  'Beguenstigter/Zahlungspflichtiger',
+  'Begünstigter/Zahlungspflichtiger',
+  'Auftraggeber/Empfänger',
+  'Auftraggeber',
+  'Empfänger',
+  'Name',
+  'Partner',
+];
+const USAGE_KEYS = ['Verwendungszweck', 'Verwendung'];
+
+function stripDiacritics(text) {
+  return String(text || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+function getFirstMatchingKey(row, keys) {
+  return keys.find((key) => Object.prototype.hasOwnProperty.call(row, key) && row[key]);
+}
+
+function getTransactionType(row) {
+  const key = getFirstMatchingKey(row, TYPE_KEYS);
+  if (!key) return '';
+  return String(row[key] || '').trim();
+}
+
+function normalizeForComparison(value) {
+  if (!value && value !== 0) return '';
+  return String(value).trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function isLikelyPersonName(value) {
+  if (!value && value !== 0) return false;
+  const text = String(value).trim();
+  if (!text) return false;
+  if (/\d/.test(text)) return false;
+
+  const words = text.split(/\s+/).filter(Boolean);
+  if (words.length < 2 || words.length > 4) {
+    return false;
+  }
+
+  const lastWord = words[words.length - 1];
+  if (COMPANY_SUFFIXES.includes(lastWord.toLowerCase())) {
+    return false;
+  }
+
+  const hasLowercase = words.some((word) => /[a-zäöüß]/.test(word));
+  if (hasLowercase) {
+    return words.every((word) => /^[A-ZÄÖÜ][A-Za-zÄÖÜäöüß'\-]+$/.test(word));
+  }
+
+  if (!words.every((word) => /^[A-ZÄÖÜß'\-]{2,}$/.test(word))) {
+    return false;
+  }
+
+  if (lastWord.length <= 2) {
+    return words.length >= 3;
+  }
+
+  return true;
+}
+
+function getLastName(value) {
+  if (!value && value !== 0) return '';
+  const words = String(value)
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (words.length < 2) {
+    return '';
+  }
+  return words[words.length - 1];
+}
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function maskDigits(value) {
+  if (!value && value !== 0) return value;
+  return String(value).replace(/\d+/g, 'XXX');
+}
+
+function maskName(text, lastName) {
+  if (!text && text !== 0) return text;
+  if (!lastName) return text;
+  const pattern = new RegExp(`\\b${escapeRegExp(String(lastName))}\\b`, 'gi');
+  return String(text).replace(pattern, 'XXX');
+}
+
+// Remove sensitive information according to transaction rules
 function anonymize(data) {
   return data.map((row) => {
-    if (row['Verwendungszweck']) {
-      let text = row['Verwendungszweck'];
-      // Replace long numbers (4+ digits) with ***
-      text = text.replace(/\b\d{4,}\b/g, '***');
-      // Replace names (simple heuristic: words starting with a capital letter)
-      text = text.replace(/\b[A-ZÄÖÜ][a-zäöüß]+/g, 'XXX');
-      row['Verwendungszweck'] = text;
+    const updated = { ...row };
+
+    const usageKey = getFirstMatchingKey(row, USAGE_KEYS);
+    const partnerKey = getFirstMatchingKey(row, PARTNER_KEYS);
+    const usage = usageKey ? row[usageKey] : undefined;
+    const partner = partnerKey ? row[partnerKey] : undefined;
+
+    if (
+      usageKey &&
+      partnerKey &&
+      usage &&
+      partner &&
+      normalizeForComparison(usage) === normalizeForComparison(partner) &&
+      !isLikelyPersonName(partner)
+    ) {
+      return { ...row };
     }
-    return row;
+
+    const type = stripDiacritics(getTransactionType(row).toLowerCase()).replace(/^ruck/, 'rueck');
+
+    if (type === 'clearing') {
+      return { ...row };
+    }
+
+    if (type === 'lastschrift' || type === 'ruecklastschrift') {
+      if (usageKey && usage) {
+        updated[usageKey] = maskDigits(usage);
+      }
+      return updated;
+    }
+
+    if (type === 'uberweisung') {
+      if (partnerKey && partner && isLikelyPersonName(partner)) {
+        const lastName = getLastName(partner);
+        if (lastName) {
+          if (usageKey && usage) {
+            updated[usageKey] = maskName(usage, lastName);
+          }
+          updated[partnerKey] = maskName(partner, lastName);
+        }
+      } else if (usageKey && usage) {
+        updated[usageKey] = maskDigits(usage);
+      }
+      return updated;
+    }
+
+    if (type === 'aufladung') {
+      if (partnerKey && partner && isLikelyPersonName(partner)) {
+        const lastName = getLastName(partner);
+        if (lastName) {
+          if (usageKey && usage) {
+            updated[usageKey] = maskName(usage, lastName);
+          }
+          updated[partnerKey] = maskName(partner, lastName);
+        }
+      }
+      return updated;
+    }
+
+    return updated;
   });
 }
 

--- a/app.js
+++ b/app.js
@@ -333,16 +333,18 @@ function anonymize(data) {
     }
 
     if (type === 'uberweisung') {
+      if (usageKey && usage) {
+        updated[usageKey] = maskDigits(usage);
+      }
+
       if (partnerKey && partner && isLikelyPersonName(partner)) {
         const lastName = getLastName(partner);
         if (lastName) {
-          if (usageKey && usage) {
-            updated[usageKey] = maskName(usage, lastName);
+          if (usageKey && updated[usageKey]) {
+            updated[usageKey] = maskName(updated[usageKey], lastName);
           }
           updated[partnerKey] = maskName(partner, lastName);
         }
-      } else if (usageKey && usage) {
-        updated[usageKey] = maskDigits(usage);
       }
 
       if (usageKey && updated[usageKey]) {
@@ -355,11 +357,15 @@ function anonymize(data) {
     }
 
     if (type === 'aufladung') {
+      if (usageKey && usage) {
+        updated[usageKey] = maskDigits(usage);
+      }
+
       if (partnerKey && partner && isLikelyPersonName(partner)) {
         const lastName = getLastName(partner);
         if (lastName) {
-          if (usageKey && usage) {
-            updated[usageKey] = maskName(usage, lastName);
+          if (usageKey && updated[usageKey]) {
+            updated[usageKey] = maskName(updated[usageKey], lastName);
           }
           updated[partnerKey] = maskName(partner, lastName);
         }

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -73,18 +73,18 @@ test('anonymize replaces digit sequences for Lastschrift and Rücklastschrift', 
   assert.strictEqual(anonymized[1].Verwendungszweck, 'Rückgabe XXX-XXX');
 });
 
-test('anonymize masks last names for transfers to private persons', () => {
+test('anonymize masks last names and digits for transfers to private persons', () => {
   const rows = [
     {
       Type: 'Überweisung',
-      Verwendungszweck: 'Miete für Max Mustermann',
+      Verwendungszweck: 'Miete 12345 für Max Mustermann',
       Zahlungspartner: 'Max Mustermann',
     },
   ];
 
   const [result] = anonymize(rows);
 
-  assert.strictEqual(result.Verwendungszweck, 'Miete für Max XXX');
+  assert.strictEqual(result.Verwendungszweck, 'Miete XXX für Max XXX');
   assert.strictEqual(result.Zahlungspartner, 'Max XXX');
 });
 
@@ -117,18 +117,18 @@ test('anonymize keeps identical usage and partner text for companies', () => {
   assert.deepStrictEqual(result, rows[0]);
 });
 
-test('anonymize masks last names for top-ups from private persons', () => {
+test('anonymize masks last names and digits for top-ups from private persons', () => {
   const rows = [
     {
       Type: 'Aufladung',
-      Verwendungszweck: 'Aufladung Anna Lena Meier',
+      Verwendungszweck: 'Aufladung 9876 Anna Lena Meier',
       Zahlungspartner: 'ANNA LENA MEIER',
     },
   ];
 
   const [result] = anonymize(rows);
 
-  assert.strictEqual(result.Verwendungszweck, 'Aufladung Anna Lena XXX');
+  assert.strictEqual(result.Verwendungszweck, 'Aufladung XXX Anna Lena XXX');
   assert.strictEqual(result.Zahlungspartner, 'ANNA LENA XXX');
 });
 
@@ -296,7 +296,7 @@ test('anonymize fully protects provided example dataset', () => {
     {
       ...rows[16],
       Verwendungszweck:
-        'AZV-Ref.Nr XXX-XXX XX/XXXX K-NR. XXX Ihre Rechnung online bei www.vodafone.de/meinkabel',
+        'AZV-Ref.Nr XXX-XXX XXX/XXX K-NR. XXX Ihre Rechnung online bei www.vodafone.de/meinkabel',
     },
   ]);
 });

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -132,6 +132,175 @@ test('anonymize masks last names for top-ups from private persons', () => {
   assert.strictEqual(result.Zahlungspartner, 'ANNA LENA XXX');
 });
 
+test('anonymize fully protects provided example dataset', () => {
+  const rows = [
+    {
+      Datum: '2024-06-01 09:37:25.130000',
+      Betrag: '43,52',
+      Verwendungszweck: 'MCDONALDS 1378 - BERLIN, DEU',
+      Zahlungspartner: 'MCDONALDS 1378 - BERLIN, DEU',
+      Type: 'Clearing',
+    },
+    {
+      Datum: '2024-06-01 10:20:59.826667',
+      Betrag: '500,6',
+      Verwendungszweck: 'Schmidt, 304458',
+      Zahlungspartner: 'Plan-Finanz24 GmbH',
+      Type: 'Überweisung',
+    },
+    {
+      Datum: '2024-06-01 12:19:54.153333',
+      Betrag: '35,99',
+      Verwendungszweck: 'Hugendubel - Berlin, DEU',
+      Zahlungspartner: 'Hugendubel - Berlin, DEU',
+      Type: 'Clearing',
+    },
+    {
+      Datum: '2024-06-03 03:35:19.563333',
+      Betrag: '19,95',
+      Verwendungszweck: 'NATURKAUFHAUS - Berlin, DEU',
+      Zahlungspartner: 'NATURKAUFHAUS - Berlin, DEU',
+      Type: 'Clearing',
+    },
+    {
+      Datum: '2024-06-04 06:08:51.253333',
+      Betrag: '9,06',
+      Verwendungszweck: 'Lidl sagt Danke - Berlin, DEU',
+      Zahlungspartner: 'Lidl sagt Danke - Berlin, DEU',
+      Type: 'Clearing',
+    },
+    {
+      Datum: '2024-06-04 11:24:13.906667',
+      Betrag: '8,53',
+      Verwendungszweck: 'REWE Markt GmbH-Zw - Berlin, DEU',
+      Zahlungspartner: 'REWE Markt GmbH-Zw - Berlin, DEU',
+      Type: 'Clearing',
+    },
+    {
+      Datum: '2024-06-04 16:50:41.443333',
+      Betrag: '29,6',
+      Verwendungszweck: 'Überweisung',
+      Zahlungspartner: 'Detlef Schmidt',
+      Type: 'Überweisung',
+    },
+    {
+      Datum: '2024-06-05 06:11:20.276667',
+      Betrag: '1000',
+      Verwendungszweck: 'COMMERZBANK ATM - BERLIN, DEU',
+      Zahlungspartner: 'COMMERZBANK ATM - BERLIN, DEU',
+      Type: 'Clearing',
+    },
+    {
+      Datum: '2024-06-07 10:09:41.333333',
+      Betrag: '30,01',
+      Verwendungszweck: 'SPRINT STATION 600020 - Berlin, DEU',
+      Zahlungspartner: 'SPRINT STATION 600020 - Berlin, DEU',
+      Type: 'Clearing',
+    },
+    {
+      Datum: '2024-06-07 10:20:15.493333',
+      Betrag: '29,6',
+      Verwendungszweck: 'Renault Megane Versicherung',
+      Zahlungspartner: 'Detlef Schmidt',
+      Type: 'Überweisung',
+    },
+    {
+      Datum: '2024-06-08 09:33:38.993333',
+      Betrag: '12,03',
+      Verwendungszweck: 'REWE Markt GmbH-Zw - Berlin, DEU',
+      Zahlungspartner: 'REWE Markt GmbH-Zw - Berlin, DEU',
+      Type: 'Clearing',
+    },
+    {
+      Datum: '2024-06-09 05:55:32.356667',
+      Betrag: '32,6',
+      Verwendungszweck: 'Nespresso - Duesseldorf, DEU',
+      Zahlungspartner: 'Nespresso - Duesseldorf, DEU',
+      Type: 'Clearing',
+    },
+    {
+      Datum: '2024-06-10 13:27:27.086667',
+      Betrag: '150,6',
+      Verwendungszweck: 'Rate für Garten ',
+      Zahlungspartner: 'Sabine Schmidt',
+      Type: 'Überweisung',
+    },
+    {
+      Datum: '2024-06-10 13:34:25.776667',
+      Betrag: '46,6',
+      Verwendungszweck: '837000000000',
+      Zahlungspartner: 'Vattenfall Europe Sales GmbH',
+      Type: 'Überweisung',
+    },
+    {
+      Datum: '2024-06-10 13:34:53.566667',
+      Betrag: '21,6',
+      Verwendungszweck: '837000000000',
+      Zahlungspartner: 'Vattenfall Europe Sales GmbH',
+      Type: 'Überweisung',
+    },
+    {
+      Datum: '2024-06-13 05:29:10.003333',
+      Betrag: '2,25',
+      Verwendungszweck: 'Rossmann 3630 - Berlin, DEU',
+      Zahlungspartner: 'Rossmann 3630 - Berlin, DEU',
+      Type: 'Clearing',
+    },
+    {
+      Datum: '2024-06-13 16:34:25.287000',
+      Betrag: '58,98',
+      Verwendungszweck:
+        'AZV-Ref.Nr 24381922-476 06/2024 K-NR. 332810006 Ihre Rechnung online bei www.vodafone.de/meinkabel',
+      Zahlungspartner: 'Vodafone Deutschland GmbH',
+      Type: 'Lastschrift',
+    },
+  ];
+
+  const anonymized = anonymize(rows);
+
+  assert.deepStrictEqual(anonymized, [
+    rows[0],
+    {
+      ...rows[1],
+      Verwendungszweck: 'XXX, XXX',
+    },
+    rows[2],
+    rows[3],
+    rows[4],
+    rows[5],
+    {
+      ...rows[6],
+      Zahlungspartner: 'Detlef XXX',
+    },
+    rows[7],
+    rows[8],
+    {
+      ...rows[9],
+      Zahlungspartner: 'Detlef XXX',
+    },
+    rows[10],
+    rows[11],
+    {
+      ...rows[12],
+      Zahlungspartner: 'Sabine XXX',
+    },
+    {
+      ...rows[13],
+      Verwendungszweck: 'XXX',
+    },
+    {
+      ...rows[14],
+      Verwendungszweck: 'XXX',
+    },
+    rows[15],
+    {
+      ...rows[16],
+      Verwendungszweck:
+        'AZV-Ref.Nr XXX-XXX XX/XXXX K-NR. XXX Ihre Rechnung online bei www.vodafone.de/meinkabel',
+    },
+  ]);
+});
+
 test('parseDateString handles german and iso formats and ignores invalid', () => {
   const german = parseDateString('15.03.2024');
   const iso = parseDateString('2024-03-16');

--- a/test/frontend.test.js
+++ b/test/frontend.test.js
@@ -103,6 +103,21 @@ test('anonymize masks digits for transfers to companies', () => {
   assert.strictEqual(result.Zahlungspartner, 'Supermarkt GmbH');
 });
 
+test('anonymize masks digits in usage for transfers even when identical to partner', () => {
+  const rows = [
+    {
+      Type: 'Überweisung',
+      Verwendungszweck: 'ACME 12345',
+      Zahlungspartner: 'ACME 12345',
+    },
+  ];
+
+  const [result] = anonymize(rows);
+
+  assert.strictEqual(result.Verwendungszweck, 'ACME XXX');
+  assert.strictEqual(result.Zahlungspartner, 'ACME 12345');
+});
+
 test('anonymize keeps identical usage and partner text for companies', () => {
   const rows = [
     {


### PR DESCRIPTION
## Summary
- add transaction-type aware anonymization that respects digits and name masking rules
- introduce heuristics for recognising private individuals versus companies to minimise over-masking
- expand frontend tests to cover the new anonymisation scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5879c02788333a184b5da3b108fe8