### PR TITLE
Fix GitHub Pages workflow dependency install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build production bundle
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ npm run dev
 
 Der Entwicklungsserver startet standardmäßig unter <http://localhost:5173>.
 
+## Produktion & Deployment
+
+```bash
+npm run build
+```
+
+Der Befehl erzeugt ein statisches Produktions-Bundle im Ordner `dist/`, das von jedem beliebigen Static-File-Host (z. B. GitHub Pages) bedient werden kann. Der bereitgestellte GitHub-Actions-Workflow `Deploy to GitHub Pages` baut das Projekt bei jedem Push auf den `main`-Branch, lädt das `dist/`-Artefakt hoch und veröffentlicht es über GitHub Pages.
+
+Nach erfolgreicher Bereitstellung lädt die ausgelieferte Seite die kompilierten Assets aus `dist/assets/…` – ein direkter Verweis auf `/src/main.tsx` wird nicht mehr benötigt.
+
 ## Tests
 
 ```bash

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  // Use relative asset URLs in the production build so the bundle can be
+  // hosted from GitHub Pages or any other sub-path without additional rewrites
+  // while keeping the dev server mounted at the default root during `npm run dev`.
+  base: command === 'build' ? './' : '/',
   plugins: [react()],
   test: {
     environment: 'jsdom',
     globals: true
   }
-});
+}));


### PR DESCRIPTION
## Summary
- run `npm install` in the Pages workflow so the build succeeds without a lockfile
- scope the Vite `base` override to production builds so local dev still runs from the root

## Testing
- npm install --package-lock-only *(fails: 403 Forbidden from registry.npmjs.org in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da805202c0833390973d1fc79c1e80