### PR TITLE
Add collapsible sections and rule apply preview

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -267,6 +267,26 @@ function handleSaveRules() {
         setStatus("Anonymisierungsregeln gespeichert.", "info");
     }
 }
+function handleApplySingleRule(rule) {
+    const baseData = anonymizedActive ? anonymizedCache : transactions;
+    if (baseData.length === 0) {
+        setStatus("Keine Daten zum Anwenden der Regel vorhanden.", "warning");
+        return;
+    }
+    const result = applyAnonymization(baseData, [rule]);
+    anonymizedCache = result.data;
+    anonymizedActive = true;
+    lastAnonymizationWarnings = result.warnings;
+    ensuredAnonymizeButton.textContent = "Original anzeigen";
+    ensuredSaveMaskedButton.disabled = anonymizedCache.length === 0;
+    renderTransactions(anonymizedCache);
+    if (lastAnonymizationWarnings.length > 0) {
+        setStatus(`Regel "${rule.id}" angewendet. ${lastAnonymizationWarnings.join(" ")}`, "warning");
+    }
+    else {
+        setStatus(`Regel "${rule.id}" angewendet.`, "info");
+    }
+}
 function init() {
     transactions = loadTransactions();
     renderTransactions(transactions);
@@ -301,6 +321,12 @@ function init() {
     rulesController = buildRulesUI(ensuredRulesContainer);
     const { rules } = loadAnonymizationRules();
     rulesController.setRules(rules);
+    ensuredRulesContainer.addEventListener("ruleapply", (event) => {
+        const customEvent = event;
+        if (customEvent.detail) {
+            handleApplySingleRule(customEvent.detail);
+        }
+    });
     ensuredSaveRulesButton.addEventListener("click", (event) => {
         event.preventDefault();
         handleSaveRules();

--- a/index.html
+++ b/index.html
@@ -12,31 +12,43 @@
     <main>
       <h1>Umsätze importieren &amp; anonymisieren</h1>
 
-      <section>
-        <h2>CSV-Import</h2>
-        <label for="csvInput">CSV wählen</label>
-        <input id="csvInput" type="file" accept=".csv,text/csv" />
-        <label for="bankName">Bankname</label>
-        <input id="bankName" type="text" placeholder="z. B. comdirect" />
-      </section>
-
-      <section>
-        <h2>Mapping auf Zielschema</h2>
-        <div id="mappingContainer"></div>
-        <div class="button-row">
-          <button id="saveMappingButton" type="button">Mapping speichern</button>
-          <button id="importButton" type="button">Import starten</button>
+      <details class="collapsible-section" open>
+        <summary>
+          <h2>CSV-Import</h2>
+        </summary>
+        <div class="collapsible-content">
+          <label for="csvInput">CSV wählen</label>
+          <input id="csvInput" type="file" accept=".csv,text/csv" />
+          <label for="bankName">Bankname</label>
+          <input id="bankName" type="text" placeholder="z. B. comdirect" />
         </div>
-        <div id="statusArea" data-status="info"></div>
-      </section>
+      </details>
 
-      <section>
-        <h2>Anonymisierungsregeln</h2>
-        <div id="rulesContainer"></div>
-        <div class="button-row">
-          <button id="saveRulesButton" type="button">Regeln speichern</button>
+      <details class="collapsible-section" open>
+        <summary>
+          <h2>Mapping auf Zielschema</h2>
+        </summary>
+        <div class="collapsible-content">
+          <div id="mappingContainer"></div>
+          <div class="button-row">
+            <button id="saveMappingButton" type="button">Mapping speichern</button>
+            <button id="importButton" type="button">Import starten</button>
+          </div>
+          <div id="statusArea" data-status="info"></div>
         </div>
-      </section>
+      </details>
+
+      <details class="collapsible-section" open>
+        <summary>
+          <h2>Anonymisierungsregeln</h2>
+        </summary>
+        <div class="collapsible-content">
+          <div id="rulesContainer"></div>
+          <div class="button-row">
+            <button id="saveRulesButton" type="button">Regeln speichern</button>
+          </div>
+        </div>
+      </details>
 
       <section>
         <h2>Übersicht</h2>

--- a/src/rulesUI.ts
+++ b/src/rulesUI.ts
@@ -149,6 +149,7 @@ export function buildRulesUI(container: HTMLElement): RulesUIController {
   container.appendChild(addButton);
 
   const state: AnonRule[] = [];
+  const openStates = new Map<string, boolean>();
 
   function notifyChange(): void {
     const event = new CustomEvent<AnonRule[]>("ruleschange", {
@@ -158,15 +159,35 @@ export function buildRulesUI(container: HTMLElement): RulesUIController {
   }
 
   function updateRule(index: number, updater: (rule: AnonRule) => AnonRule): void {
+    const previousId = state[index].id;
     state[index] = cloneRule(updater(state[index]));
+    const nextId = state[index].id;
+    if (previousId !== nextId) {
+      const wasExpanded = openStates.get(previousId);
+      openStates.delete(previousId);
+      if (wasExpanded !== undefined) {
+        openStates.set(nextId, wasExpanded);
+      }
+    }
     render();
     notifyChange();
   }
 
   function removeRule(index: number): void {
-    state.splice(index, 1);
+    const removed = state.splice(index, 1)[0];
+    if (removed) {
+      openStates.delete(removed.id);
+    }
     render();
     notifyChange();
+  }
+
+  function dispatchApplyRule(rule: AnonRule): void {
+    const event = new CustomEvent<AnonRule>("ruleapply", {
+      detail: cloneRule(rule),
+      bubbles: true,
+    });
+    container.dispatchEvent(event);
   }
 
   function render(): void {
@@ -183,14 +204,40 @@ export function buildRulesUI(container: HTMLElement): RulesUIController {
     state.forEach((rule, index) => {
       const card = document.createElement("div");
       card.className = "rule-card";
+      card.dataset.ruleId = rule.id;
+
+      if (!openStates.has(rule.id)) {
+        openStates.set(rule.id, true);
+      }
+
+      const expanded = openStates.get(rule.id) !== false;
+      if (!expanded) {
+        card.classList.add("rule-card-collapsed");
+      }
 
       const header = document.createElement("div");
       header.className = "rule-card-header";
 
-      const idField = createTextInput("Name", rule.id, (value) => {
-        updateRule(index, (current) => ({ ...current, id: value.trim() || current.id }));
+      const toggleButton = document.createElement("button");
+      toggleButton.type = "button";
+      toggleButton.className = "rule-collapse-toggle";
+      toggleButton.setAttribute("aria-expanded", String(expanded));
+      toggleButton.textContent = expanded ? "▼" : "▶";
+      toggleButton.addEventListener("click", () => {
+        const isCollapsed = card.classList.toggle("rule-card-collapsed");
+        const isExpanded = !isCollapsed;
+        openStates.set(rule.id, isExpanded);
+        toggleButton.textContent = isExpanded ? "▼" : "▶";
+        toggleButton.setAttribute("aria-expanded", String(isExpanded));
       });
-      idField.classList.add("rule-field-inline");
+
+      const nameDisplay = document.createElement("span");
+      nameDisplay.className = "rule-name-display";
+      nameDisplay.textContent = rule.id;
+      nameDisplay.title = "Regel ein- oder ausklappen";
+      nameDisplay.addEventListener("click", () => {
+        toggleButton.click();
+      });
 
       const enabledWrapper = document.createElement("label");
       enabledWrapper.className = "rule-toggle";
@@ -205,16 +252,44 @@ export function buildRulesUI(container: HTMLElement): RulesUIController {
       enabledWrapper.appendChild(enabledCheckbox);
       enabledWrapper.appendChild(enabledText);
 
+      const actions = document.createElement("div");
+      actions.className = "rule-card-actions";
+
+      const applyButton = document.createElement("button");
+      applyButton.type = "button";
+      applyButton.className = "rule-apply-button";
+      applyButton.textContent = "Regel anwenden";
+      applyButton.addEventListener("click", () => {
+        dispatchApplyRule(rule);
+      });
+
       const removeButton = document.createElement("button");
       removeButton.type = "button";
       removeButton.className = "rule-remove-button";
       removeButton.textContent = "Regel entfernen";
       removeButton.addEventListener("click", () => removeRule(index));
 
-      header.appendChild(idField);
-      header.appendChild(enabledWrapper);
-      header.appendChild(removeButton);
+      actions.appendChild(applyButton);
+      actions.appendChild(removeButton);
+
+      const controls = document.createElement("div");
+      controls.className = "rule-card-controls";
+      controls.appendChild(enabledWrapper);
+      controls.appendChild(actions);
+
+      header.appendChild(toggleButton);
+      header.appendChild(nameDisplay);
+      header.appendChild(controls);
       card.appendChild(header);
+
+      const body = document.createElement("div");
+      body.className = "rule-card-body";
+
+      const idField = createTextInput("Name", rule.id, (value) => {
+        updateRule(index, (current) => ({ ...current, id: value.trim() || current.id }));
+      });
+      idField.classList.add("rule-field-inline");
+      body.appendChild(idField);
 
       const typeWrapper = document.createElement("div");
       typeWrapper.className = "rule-field";
@@ -258,20 +333,20 @@ export function buildRulesUI(container: HTMLElement): RulesUIController {
       });
       typeWrapper.appendChild(typeLabel);
       typeWrapper.appendChild(typeSelect);
-      card.appendChild(typeWrapper);
+      body.appendChild(typeWrapper);
 
       if (rule.type === "regex") {
-        card.appendChild(
+        body.appendChild(
           createTextInput("Regulärer Ausdruck", rule.pattern, (value) => {
             updateRule(index, (current) => ({ ...current, pattern: value }));
           })
         );
-        card.appendChild(
+        body.appendChild(
           createTextInput("Ersetzung", rule.replacement, (value) => {
             updateRule(index, (current) => ({ ...current, replacement: value }));
           })
         );
-        card.appendChild(
+        body.appendChild(
           createTextInput("Flags", rule.flags ?? "", (value) => {
             updateRule(index, (current) => ({ ...current, flags: value.trim() || undefined }));
           })
@@ -304,33 +379,36 @@ export function buildRulesUI(container: HTMLElement): RulesUIController {
         });
         strategyWrapper.appendChild(strategyLabel);
         strategyWrapper.appendChild(strategySelect);
-        card.appendChild(strategyWrapper);
+        body.appendChild(strategyWrapper);
 
-        card.appendChild(
+        body.appendChild(
           createTextInput("Masken-Zeichen", rule.maskChar ?? "", (value) => {
             updateRule(index, (current) => ({ ...current, maskChar: value || undefined }));
           })
         );
 
-        card.appendChild(
+        body.appendChild(
           createNumberInput("Mindestlänge", rule.minLen, (value) => {
             updateRule(index, (current) => ({ ...current, minLen: value }));
           }, { min: 0 })
         );
 
-        card.appendChild(
+        body.appendChild(
           createMaskPercentInput("Maskierungsanteil", rule.maskPercent, (value) => {
             updateRule(index, (current) => ({ ...current, maskPercent: value }));
           })
         );
       }
 
+      card.appendChild(body);
       list.appendChild(card);
     });
   }
 
   addButton.addEventListener("click", () => {
-    state.push(cloneRule(createDefaultRule()));
+    const newRule = cloneRule(createDefaultRule());
+    state.push(newRule);
+    openStates.set(newRule.id, true);
     render();
     notifyChange();
   });
@@ -343,6 +421,10 @@ export function buildRulesUI(container: HTMLElement): RulesUIController {
     },
     setRules(rules: AnonRule[]): void {
       state.splice(0, state.length, ...rules.map((rule) => cloneRule(rule)));
+      openStates.clear();
+      state.forEach((rule) => {
+        openStates.set(rule.id, true);
+      });
       render();
     },
   };

--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,47 @@ section {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
+.collapsible-section {
+  background: #fff;
+  border-radius: 12px;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.collapsible-section > summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  gap: 0.75rem;
+  list-style: none;
+  padding: 1.5rem;
+}
+
+.collapsible-section > summary::-webkit-details-marker {
+  display: none;
+}
+
+.collapsible-section > summary h2 {
+  margin: 0;
+  flex: 1;
+}
+
+.collapsible-section > summary::after {
+  content: "▼";
+  font-size: 0.85rem;
+  color: #666;
+}
+
+.collapsible-section:not([open]) > summary::after {
+  content: "▶";
+}
+
+.collapsible-content {
+  border-top: 1px solid #e3e8ef;
+  padding: 1.25rem 1.5rem 1.5rem;
+}
+
 label {
   display: block;
   font-weight: 600;
@@ -117,8 +158,9 @@ select[multiple] {
 .rule-card {
   border: 1px solid #d9e2ff;
   border-radius: 12px;
-  padding: 1rem;
   background: #f6f8ff;
+  display: flex;
+  flex-direction: column;
 }
 
 .rule-card-header {
@@ -126,7 +168,52 @@ select[multiple] {
   flex-wrap: wrap;
   align-items: center;
   gap: 0.75rem;
-  margin-bottom: 1rem;
+  padding: 0.75rem 1rem;
+}
+
+.rule-collapse-toggle {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.1rem;
+}
+
+.rule-collapse-toggle:hover {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.rule-name-display {
+  font-weight: 600;
+  cursor: pointer;
+  flex: 1;
+  min-width: 180px;
+}
+
+.rule-card-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-left: auto;
+}
+
+.rule-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.rule-card-body {
+  border-top: 1px solid #d9e2ff;
+  padding: 0 1rem 1rem;
+}
+
+.rule-card.rule-card-collapsed .rule-card-body {
+  display: none;
 }
 
 .rule-field {
@@ -163,6 +250,14 @@ select[multiple] {
   margin: 0;
 }
 
+.rule-apply-button {
+  background: #4caf50;
+}
+
+.rule-apply-button:hover {
+  background: #2e7d32;
+}
+
 .rule-remove-button {
   background: #e53935;
 }
@@ -181,7 +276,7 @@ select[multiple] {
   font-family: monospace;
 }
 
-button {
+button:not(.rule-collapse-toggle) {
   padding: 0.6rem 1rem;
   border-radius: 999px;
   border: none;
@@ -191,12 +286,12 @@ button {
   transition: background 0.2s ease;
 }
 
-button:disabled {
+button:not(.rule-collapse-toggle):disabled {
   background: #ccc;
   cursor: not-allowed;
 }
 
-button:hover:not(:disabled) {
+button:not(.rule-collapse-toggle):hover:not(:disabled) {
   background: #075ec7;
 }
 
@@ -264,6 +359,19 @@ tbody tr:nth-child(odd) {
     box-shadow: none;
   }
 
+  .collapsible-section {
+    background: #1c1c1c;
+    box-shadow: none;
+  }
+
+  .collapsible-content {
+    border-color: #2a2a2a;
+  }
+
+  .collapsible-section > summary::after {
+    color: #9e9e9e;
+  }
+
   input[type="text"],
   input[type="number"],
   select[multiple] {
@@ -295,6 +403,22 @@ tbody tr:nth-child(odd) {
   .rule-card {
     background: #1f2937;
     border-color: #2d3a5c;
+  }
+
+  .rule-card-body {
+    border-color: #2d3a5c;
+  }
+
+  .rule-collapse-toggle:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .rule-apply-button {
+    background: #43a047;
+  }
+
+  .rule-apply-button:hover {
+    background: #2e7d32;
   }
 
   .rule-remove-button {


### PR DESCRIPTION
## Summary
- make the CSV import, mapping, and anonymization sections collapsible using details/summary wrappers
- rework rule cards to support collapsing, inline enable/remove/apply controls, and dispatching a ruleapply event
- hook the ruleapply event to preview a single rule against the current table and adjust styling for the new UI affordances

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd998315a48333898e52ded7ccc458