### PR TITLE
Add configurable booking date parsing and formatting

### DIFF
--- a/dist/dateFormat.js
+++ b/dist/dateFormat.js
@@ -1,0 +1,142 @@
+const TOKEN_REGEX = /(yyyy|MM|dd|HH|mm|ss|SSS)/g;
+const TOKEN_PATTERNS = {
+    yyyy: {
+        pattern: "\\d{4}",
+        apply: (value, parts) => {
+            parts.year = Number.parseInt(value, 10);
+        },
+    },
+    MM: {
+        pattern: "\\d{2}",
+        apply: (value, parts) => {
+            parts.month = Number.parseInt(value, 10);
+        },
+    },
+    dd: {
+        pattern: "\\d{2}",
+        apply: (value, parts) => {
+            parts.day = Number.parseInt(value, 10);
+        },
+    },
+    HH: {
+        pattern: "\\d{2}",
+        apply: (value, parts) => {
+            parts.hour = Number.parseInt(value, 10);
+        },
+    },
+    mm: {
+        pattern: "\\d{2}",
+        apply: (value, parts) => {
+            parts.minute = Number.parseInt(value, 10);
+        },
+    },
+    ss: {
+        pattern: "\\d{2}",
+        apply: (value, parts) => {
+            parts.second = Number.parseInt(value, 10);
+        },
+    },
+    SSS: {
+        pattern: "\\d{3}",
+        apply: (value, parts) => {
+            parts.millisecond = Number.parseInt(value, 10);
+        },
+    },
+};
+const TOKEN_FORMATTERS = {
+    yyyy: (date) => date.getFullYear().toString().padStart(4, "0"),
+    MM: (date) => (date.getMonth() + 1).toString().padStart(2, "0"),
+    dd: (date) => date.getDate().toString().padStart(2, "0"),
+    HH: (date) => date.getHours().toString().padStart(2, "0"),
+    mm: (date) => date.getMinutes().toString().padStart(2, "0"),
+    ss: (date) => date.getSeconds().toString().padStart(2, "0"),
+    SSS: (date) => date.getMilliseconds().toString().padStart(3, "0"),
+};
+function escapeRegExp(literal) {
+    return literal.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&");
+}
+export function parseDateWithFormat(value, format) {
+    const trimmedFormat = format.trim();
+    if (!trimmedFormat) {
+        return null;
+    }
+    const tokenRegex = /yyyy|MM|dd|HH|mm|ss|SSS/g;
+    let pattern = "";
+    const setters = [];
+    let lastIndex = 0;
+    let match;
+    while ((match = tokenRegex.exec(trimmedFormat)) !== null) {
+        const literal = trimmedFormat.slice(lastIndex, match.index);
+        if (literal.length > 0) {
+            pattern += escapeRegExp(literal);
+        }
+        const token = match[0];
+        const tokenPattern = TOKEN_PATTERNS[token];
+        if (!tokenPattern) {
+            pattern += escapeRegExp(token);
+        }
+        else {
+            pattern += `(${tokenPattern.pattern})`;
+            setters.push((segment, parts) => tokenPattern.apply(segment, parts));
+        }
+        lastIndex = match.index + token.length;
+    }
+    const remaining = trimmedFormat.slice(lastIndex);
+    if (remaining.length > 0) {
+        pattern += escapeRegExp(remaining);
+    }
+    if (pattern.length === 0) {
+        return null;
+    }
+    const regex = new RegExp(`^${pattern}$`);
+    const result = regex.exec(value.trim());
+    if (!result) {
+        return null;
+    }
+    const parts = {};
+    setters.forEach((setter, index) => {
+        const segment = result[index + 1];
+        setter(segment, parts);
+    });
+    if (parts.year === undefined ||
+        parts.month === undefined ||
+        parts.day === undefined) {
+        return null;
+    }
+    const date = new Date(parts.year, (parts.month ?? 1) - 1, parts.day ?? 1, parts.hour ?? 0, parts.minute ?? 0, parts.second ?? 0, parts.millisecond ?? 0);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+    if (date.getFullYear() !== parts.year) {
+        return null;
+    }
+    if (parts.month !== undefined && date.getMonth() !== parts.month - 1) {
+        return null;
+    }
+    if (parts.day !== undefined && date.getDate() !== parts.day) {
+        return null;
+    }
+    if (parts.hour !== undefined && date.getHours() !== parts.hour) {
+        return null;
+    }
+    if (parts.minute !== undefined && date.getMinutes() !== parts.minute) {
+        return null;
+    }
+    if (parts.second !== undefined && date.getSeconds() !== parts.second) {
+        return null;
+    }
+    if (parts.millisecond !== undefined && date.getMilliseconds() !== parts.millisecond) {
+        return null;
+    }
+    return date;
+}
+export function formatDateWithFormat(date, format) {
+    const trimmedFormat = format.trim();
+    if (!trimmedFormat) {
+        return date.toISOString();
+    }
+    return trimmedFormat.replace(TOKEN_REGEX, (token) => {
+        const formatter = TOKEN_FORMATTERS[token];
+        return formatter ? formatter(date) : token;
+    });
+}

--- a/dist/storage.js
+++ b/dist/storage.js
@@ -6,16 +6,47 @@ const CURRENT_RULE_VERSION = 2;
 function isStringArray(value) {
     return Array.isArray(value) && value.every((entry) => typeof entry === "string");
 }
-function isBankMapping(value) {
+function toBankMapping(value) {
     if (typeof value !== "object" || value === null) {
-        return false;
+        return null;
     }
     const maybe = value;
-    return (typeof maybe.bank_name === "string" &&
-        isStringArray(maybe.booking_date) &&
-        isStringArray(maybe.booking_text) &&
-        isStringArray(maybe.booking_type) &&
-        isStringArray(maybe.booking_amount));
+    if (typeof maybe.bank_name !== "string" ||
+        !isStringArray(maybe.booking_date) ||
+        !isStringArray(maybe.booking_text) ||
+        !isStringArray(maybe.booking_type) ||
+        !isStringArray(maybe.booking_amount)) {
+        return null;
+    }
+    const parseFormat = typeof maybe.booking_date_parse_format === "string"
+        ? maybe.booking_date_parse_format
+        : "";
+    const displayFormatRaw = typeof maybe.booking_date_display_format === "string"
+        ? maybe.booking_date_display_format
+        : parseFormat;
+    return {
+        bank_name: maybe.bank_name,
+        booking_date: [...maybe.booking_date],
+        booking_text: [...maybe.booking_text],
+        booking_type: [...maybe.booking_type],
+        booking_amount: [...maybe.booking_amount],
+        booking_date_parse_format: parseFormat,
+        booking_date_display_format: displayFormatRaw,
+    };
+}
+function sanitizeBankMapping(mapping) {
+    const parseFormat = mapping.booking_date_parse_format.trim();
+    const displayFormatRaw = mapping.booking_date_display_format.trim();
+    const displayFormat = displayFormatRaw.length > 0 ? displayFormatRaw : parseFormat;
+    return {
+        bank_name: mapping.bank_name,
+        booking_date: [...mapping.booking_date],
+        booking_text: [...mapping.booking_text],
+        booking_type: [...mapping.booking_type],
+        booking_amount: [...mapping.booking_amount],
+        booking_date_parse_format: parseFormat,
+        booking_date_display_format: displayFormat,
+    };
 }
 function safeParse(text) {
     if (!text) {
@@ -34,52 +65,131 @@ export function loadBankMappings() {
     if (!Array.isArray(parsed)) {
         return [];
     }
-    return parsed.filter(isBankMapping);
+    return parsed
+        .map(toBankMapping)
+        .filter((entry) => entry !== null)
+        .map(sanitizeBankMapping);
 }
 export function saveBankMapping(mapping) {
+    const sanitized = sanitizeBankMapping(mapping);
     const existing = loadBankMappings();
-    const index = existing.findIndex((entry) => entry.bank_name === mapping.bank_name);
+    const index = existing.findIndex((entry) => entry.bank_name === sanitized.bank_name);
     if (index >= 0) {
-        existing[index] = mapping;
+        existing[index] = sanitized;
     }
     else {
-        existing.push(mapping);
+        existing.push(sanitized);
     }
     localStorage.setItem(BANK_MAPPINGS_KEY, JSON.stringify(existing, null, 2));
 }
-function isUnifiedTx(value) {
+function toUnifiedTx(value) {
     if (typeof value !== "object" || value === null) {
-        return false;
+        return null;
     }
     const maybe = value;
-    return (typeof maybe.bank_name === "string" &&
-        typeof maybe.booking_date === "string" &&
-        typeof maybe.booking_text === "string" &&
-        typeof maybe.booking_type === "string" &&
-        typeof maybe.booking_amount === "string");
+    if (typeof maybe.bank_name !== "string" ||
+        typeof maybe.booking_date !== "string" ||
+        typeof maybe.booking_text !== "string" ||
+        typeof maybe.booking_type !== "string" ||
+        typeof maybe.booking_amount !== "string") {
+        return null;
+    }
+    const raw = typeof maybe.booking_date_raw === "string"
+        ? maybe.booking_date_raw
+        : maybe.booking_date;
+    let iso = null;
+    if (typeof maybe.booking_date_iso === "string") {
+        const time = Date.parse(maybe.booking_date_iso);
+        iso = Number.isNaN(time) ? null : maybe.booking_date_iso;
+    }
+    else if (maybe.booking_date_iso === null) {
+        iso = null;
+    }
+    return {
+        bank_name: maybe.bank_name,
+        booking_date: maybe.booking_date,
+        booking_date_raw: raw,
+        booking_date_iso: iso,
+        booking_text: maybe.booking_text,
+        booking_type: maybe.booking_type,
+        booking_amount: maybe.booking_amount,
+    };
+}
+function sanitizeTransaction(tx) {
+    const iso = tx.booking_date_iso;
+    let normalizedIso = null;
+    if (typeof iso === "string") {
+        const time = Date.parse(iso);
+        normalizedIso = Number.isNaN(time) ? null : iso;
+    }
+    return {
+        bank_name: tx.bank_name,
+        booking_date: tx.booking_date,
+        booking_date_raw: tx.booking_date_raw ?? tx.booking_date,
+        booking_date_iso: normalizedIso,
+        booking_text: tx.booking_text,
+        booking_type: tx.booking_type,
+        booking_amount: tx.booking_amount,
+    };
+}
+function transactionTimestamp(tx) {
+    if (tx.booking_date_iso) {
+        const time = Date.parse(tx.booking_date_iso);
+        if (!Number.isNaN(time)) {
+            return time;
+        }
+    }
+    const raw = Date.parse(tx.booking_date_raw);
+    if (!Number.isNaN(raw)) {
+        return raw;
+    }
+    const display = Date.parse(tx.booking_date);
+    if (!Number.isNaN(display)) {
+        return display;
+    }
+    return Number.NEGATIVE_INFINITY;
+}
+function sortTransactions(entries) {
+    return [...entries].sort((a, b) => transactionTimestamp(b) - transactionTimestamp(a));
+}
+function persistTransactions(key, entries) {
+    const sanitized = entries.map(sanitizeTransaction);
+    const sorted = sortTransactions(sanitized);
+    localStorage.setItem(key, JSON.stringify(sorted, null, 2));
 }
 export function loadTransactions() {
     const parsed = safeParse(localStorage.getItem(TRANSACTIONS_KEY));
     if (!Array.isArray(parsed)) {
         return [];
     }
-    return parsed.filter(isUnifiedTx);
+    const normalized = parsed
+        .map(toUnifiedTx)
+        .filter((entry) => entry !== null)
+        .map(sanitizeTransaction);
+    return sortTransactions(normalized);
+}
+export function saveTransactions(entries) {
+    persistTransactions(TRANSACTIONS_KEY, entries);
 }
 export function appendTransactions(entries) {
     const current = loadTransactions();
-    const next = current.concat(entries);
-    localStorage.setItem(TRANSACTIONS_KEY, JSON.stringify(next, null, 2));
-    return next;
+    const combined = current.concat(entries.map(sanitizeTransaction));
+    persistTransactions(TRANSACTIONS_KEY, combined);
+    return sortTransactions(combined);
 }
 export function loadMaskedTransactions() {
     const parsed = safeParse(localStorage.getItem(TRANSACTIONS_MASKED_KEY));
     if (!Array.isArray(parsed)) {
         return [];
     }
-    return parsed.filter(isUnifiedTx);
+    const normalized = parsed
+        .map(toUnifiedTx)
+        .filter((entry) => entry !== null)
+        .map(sanitizeTransaction);
+    return sortTransactions(normalized);
 }
 export function saveMaskedTransactions(entries) {
-    localStorage.setItem(TRANSACTIONS_MASKED_KEY, JSON.stringify(entries, null, 2));
+    persistTransactions(TRANSACTIONS_MASKED_KEY, entries);
 }
 function isAnonRule(value) {
     if (typeof value !== "object" || value === null) {

--- a/src/dateFormat.ts
+++ b/src/dateFormat.ts
@@ -1,0 +1,177 @@
+const TOKEN_REGEX = /(yyyy|MM|dd|HH|mm|ss|SSS)/g;
+
+const TOKEN_PATTERNS: Record<string, { pattern: string; apply: (value: string, parts: DateParts) => void }> = {
+  yyyy: {
+    pattern: "\\d{4}",
+    apply: (value, parts) => {
+      parts.year = Number.parseInt(value, 10);
+    },
+  },
+  MM: {
+    pattern: "\\d{2}",
+    apply: (value, parts) => {
+      parts.month = Number.parseInt(value, 10);
+    },
+  },
+  dd: {
+    pattern: "\\d{2}",
+    apply: (value, parts) => {
+      parts.day = Number.parseInt(value, 10);
+    },
+  },
+  HH: {
+    pattern: "\\d{2}",
+    apply: (value, parts) => {
+      parts.hour = Number.parseInt(value, 10);
+    },
+  },
+  mm: {
+    pattern: "\\d{2}",
+    apply: (value, parts) => {
+      parts.minute = Number.parseInt(value, 10);
+    },
+  },
+  ss: {
+    pattern: "\\d{2}",
+    apply: (value, parts) => {
+      parts.second = Number.parseInt(value, 10);
+    },
+  },
+  SSS: {
+    pattern: "\\d{3}",
+    apply: (value, parts) => {
+      parts.millisecond = Number.parseInt(value, 10);
+    },
+  },
+};
+
+const TOKEN_FORMATTERS: Record<string, (date: Date) => string> = {
+  yyyy: (date) => date.getFullYear().toString().padStart(4, "0"),
+  MM: (date) => (date.getMonth() + 1).toString().padStart(2, "0"),
+  dd: (date) => date.getDate().toString().padStart(2, "0"),
+  HH: (date) => date.getHours().toString().padStart(2, "0"),
+  mm: (date) => date.getMinutes().toString().padStart(2, "0"),
+  ss: (date) => date.getSeconds().toString().padStart(2, "0"),
+  SSS: (date) => date.getMilliseconds().toString().padStart(3, "0"),
+};
+
+interface DateParts {
+  year?: number;
+  month?: number;
+  day?: number;
+  hour?: number;
+  minute?: number;
+  second?: number;
+  millisecond?: number;
+}
+
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&");
+}
+
+export function parseDateWithFormat(value: string, format: string): Date | null {
+  const trimmedFormat = format.trim();
+  if (!trimmedFormat) {
+    return null;
+  }
+
+  const tokenRegex = /yyyy|MM|dd|HH|mm|ss|SSS/g;
+  let pattern = "";
+  const setters: ((segment: string, parts: DateParts) => void)[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenRegex.exec(trimmedFormat)) !== null) {
+    const literal = trimmedFormat.slice(lastIndex, match.index);
+    if (literal.length > 0) {
+      pattern += escapeRegExp(literal);
+    }
+    const token = match[0];
+    const tokenPattern = TOKEN_PATTERNS[token];
+    if (!tokenPattern) {
+      pattern += escapeRegExp(token);
+    } else {
+      pattern += `(${tokenPattern.pattern})`;
+      setters.push((segment, parts) => tokenPattern.apply(segment, parts));
+    }
+    lastIndex = match.index + token.length;
+  }
+
+  const remaining = trimmedFormat.slice(lastIndex);
+  if (remaining.length > 0) {
+    pattern += escapeRegExp(remaining);
+  }
+
+  if (pattern.length === 0) {
+    return null;
+  }
+
+  const regex = new RegExp(`^${pattern}$`);
+  const result = regex.exec(value.trim());
+  if (!result) {
+    return null;
+  }
+
+  const parts: DateParts = {};
+  setters.forEach((setter, index) => {
+    const segment = result[index + 1];
+    setter(segment, parts);
+  });
+
+  if (
+    parts.year === undefined ||
+    parts.month === undefined ||
+    parts.day === undefined
+  ) {
+    return null;
+  }
+
+  const date = new Date(
+    parts.year,
+    (parts.month ?? 1) - 1,
+    parts.day ?? 1,
+    parts.hour ?? 0,
+    parts.minute ?? 0,
+    parts.second ?? 0,
+    parts.millisecond ?? 0
+  );
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  if (date.getFullYear() !== parts.year) {
+    return null;
+  }
+  if (parts.month !== undefined && date.getMonth() !== parts.month - 1) {
+    return null;
+  }
+  if (parts.day !== undefined && date.getDate() !== parts.day) {
+    return null;
+  }
+  if (parts.hour !== undefined && date.getHours() !== parts.hour) {
+    return null;
+  }
+  if (parts.minute !== undefined && date.getMinutes() !== parts.minute) {
+    return null;
+  }
+  if (parts.second !== undefined && date.getSeconds() !== parts.second) {
+    return null;
+  }
+  if (parts.millisecond !== undefined && date.getMilliseconds() !== parts.millisecond) {
+    return null;
+  }
+
+  return date;
+}
+
+export function formatDateWithFormat(date: Date, format: string): string {
+  const trimmedFormat = format.trim();
+  if (!trimmedFormat) {
+    return date.toISOString();
+  }
+  return trimmedFormat.replace(TOKEN_REGEX, (token) => {
+    const formatter = TOKEN_FORMATTERS[token];
+    return formatter ? formatter(date) : token;
+  });
+}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,6 +1,7 @@
+import { formatDateWithFormat, parseDateWithFormat } from "./dateFormat.js";
 import { BankMapping, UnifiedTx } from "./types.js";
 
-type MappingSelection = Record<Exclude<keyof BankMapping, "bank_name">, string[]>;
+type MappingSelection = Omit<BankMapping, "bank_name">;
 
 function createIndexMap(header: string[]): Record<string, number> {
   const map: Record<string, number> = {};
@@ -56,14 +57,35 @@ export function applyMapping(
   const transactions: UnifiedTx[] = [];
 
   for (const row of rows) {
-    const bookingDate = firstNonEmpty(mapping.booking_date.map((column) => readValue(row, column, indexMap)));
+    const bookingDateRaw = firstNonEmpty(
+      mapping.booking_date.map((column) => readValue(row, column, indexMap))
+    );
     const bookingText = joinValues(mapping.booking_text.map((column) => readValue(row, column, indexMap)));
     const bookingType = firstNonEmpty(mapping.booking_type.map((column) => readValue(row, column, indexMap)));
     const bookingAmount = firstNonEmpty(mapping.booking_amount.map((column) => readValue(row, column, indexMap)));
 
+    const parseFormat = mapping.booking_date_parse_format?.trim() ?? "";
+    const displayFormat = mapping.booking_date_display_format?.trim() ?? "";
+
+    let bookingDateFormatted = bookingDateRaw;
+    let bookingDateIso: string | null = null;
+
+    if (parseFormat && bookingDateRaw.length > 0) {
+      const parsed = parseDateWithFormat(bookingDateRaw, parseFormat);
+      if (parsed) {
+        bookingDateIso = parsed.toISOString();
+        const effectiveDisplayFormat = displayFormat.length > 0 ? displayFormat : parseFormat;
+        bookingDateFormatted = effectiveDisplayFormat
+          ? formatDateWithFormat(parsed, effectiveDisplayFormat)
+          : bookingDateRaw;
+      }
+    }
+
     const tx: UnifiedTx = {
       bank_name: bankName,
-      booking_date: bookingDate,
+      booking_date: bookingDateFormatted,
+      booking_date_raw: bookingDateRaw,
+      booking_date_iso: bookingDateIso,
       booking_text: bookingText,
       booking_type: bookingType,
       booking_amount: bookingAmount,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,11 +4,15 @@ export interface BankMapping {
   booking_text: string[];
   booking_type: string[];
   booking_amount: string[];
+  booking_date_parse_format: string;
+  booking_date_display_format: string;
 }
 
 export interface UnifiedTx {
   bank_name: string;
   booking_date: string;
+  booking_date_raw: string;
+  booking_date_iso: string | null;
   booking_text: string;
   booking_type: string;
   booking_amount: string;

--- a/styles.css
+++ b/styles.css
@@ -131,6 +131,12 @@ select[multiple] {
   font-family: monospace;
 }
 
+.mapping-date-settings {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
 .button-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add configurable booking date parsing and display formats to bank mappings and the mapping UI
- parse and persist normalized booking dates for imports, keep transactions sorted by date, and refresh stored entries when formats change
- introduce reusable date format helpers and update styles to present the new settings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de283630288333ba0aacd3f6b30fcd