### PR TITLE
Add configurable display formatting controls for overview

### DIFF
--- a/dist/displaySettings.js
+++ b/dist/displaySettings.js
@@ -1,0 +1,171 @@
+import { formatDateWithFormat } from "./dateFormat.js";
+export const DEFAULT_DATE_DISPLAY_FORMAT = "dd.MM.yyyy HH:mm";
+export const DEFAULT_AMOUNT_DISPLAY_FORMAT = "#,##0.00";
+export function sanitizeDisplaySettings(value) {
+    const rawDate = typeof value?.booking_date_display_format === "string"
+        ? value.booking_date_display_format
+        : "";
+    const rawAmount = typeof value?.booking_amount_display_format === "string"
+        ? value.booking_amount_display_format
+        : "";
+    const trimmedDate = rawDate.trim();
+    const trimmedAmount = rawAmount.trim();
+    return {
+        booking_date_display_format: trimmedDate.length > 0 ? trimmedDate : DEFAULT_DATE_DISPLAY_FORMAT,
+        booking_amount_display_format: trimmedAmount.length > 0 ? trimmedAmount : DEFAULT_AMOUNT_DISPLAY_FORMAT,
+    };
+}
+function isValidDate(date) {
+    return Number.isFinite(date.getTime());
+}
+export function formatTransactionDate(tx, settings) {
+    if (tx.booking_date_iso) {
+        const parsed = new Date(tx.booking_date_iso);
+        if (isValidDate(parsed)) {
+            return formatDateWithFormat(parsed, settings.booking_date_display_format);
+        }
+    }
+    const fallback = tx.booking_date_raw ?? tx.booking_date ?? "";
+    return fallback;
+}
+function parseAmount(value) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return null;
+    }
+    let sanitized = trimmed.replace(/[\s'\u00A0]/g, "");
+    const lastComma = sanitized.lastIndexOf(",");
+    const lastDot = sanitized.lastIndexOf(".");
+    let decimalSeparator = "";
+    if (lastComma > lastDot) {
+        decimalSeparator = ",";
+    }
+    else if (lastDot > lastComma) {
+        decimalSeparator = ".";
+    }
+    let result = "";
+    const decimalIndex = decimalSeparator === "," ? lastComma : decimalSeparator === "." ? lastDot : -1;
+    for (let index = 0; index < sanitized.length; index += 1) {
+        const char = sanitized[index];
+        if (index === 0 && (char === "-" || char === "+")) {
+            if (char === "-") {
+                result += "-";
+            }
+            continue;
+        }
+        if (char === decimalSeparator) {
+            if (index === decimalIndex) {
+                result += ".";
+            }
+            continue;
+        }
+        if (char === "," || char === ".") {
+            continue;
+        }
+        if (/\d/.test(char)) {
+            result += char;
+        }
+    }
+    if (result === "" || result === "-") {
+        return null;
+    }
+    const parsed = Number.parseFloat(result);
+    if (!Number.isFinite(parsed)) {
+        return null;
+    }
+    return parsed;
+}
+function formatNumberWithPattern(value, pattern) {
+    const trimmedPattern = pattern.trim();
+    if (!trimmedPattern) {
+        return value.toString();
+    }
+    const firstDigitIndex = trimmedPattern.search(/[0#]/);
+    if (firstDigitIndex === -1) {
+        return value.toString();
+    }
+    const lastDigitIndex = trimmedPattern.length -
+        1 -
+        trimmedPattern
+            .split("")
+            .reverse()
+            .findIndex((char) => char === "0" || char === "#");
+    const prefix = trimmedPattern.slice(0, firstDigitIndex);
+    const suffix = trimmedPattern.slice(lastDigitIndex + 1);
+    const corePattern = trimmedPattern.slice(firstDigitIndex, lastDigitIndex + 1);
+    const decimalPos = Math.max(corePattern.lastIndexOf("."), corePattern.lastIndexOf(","));
+    let integerPattern = corePattern;
+    let fractionPattern = "";
+    let decimalChar = "";
+    if (decimalPos >= 0) {
+        decimalChar = corePattern[decimalPos];
+        integerPattern = corePattern.slice(0, decimalPos);
+        fractionPattern = corePattern.slice(decimalPos + 1);
+    }
+    let groupingChar = "";
+    for (let index = integerPattern.length - 1; index >= 0; index -= 1) {
+        const char = integerPattern[index];
+        if (char !== "#" && char !== "0") {
+            groupingChar = char;
+            break;
+        }
+    }
+    let groupingSize = 0;
+    if (groupingChar) {
+        for (let index = integerPattern.length - 1; index >= 0; index -= 1) {
+            const char = integerPattern[index];
+            if (char === "#" || char === "0") {
+                groupingSize += 1;
+            }
+            else if (char === groupingChar) {
+                break;
+            }
+        }
+    }
+    const minIntegerDigits = (integerPattern.match(/0/g) ?? []).length;
+    const cleanedFraction = fractionPattern.replace(/[^0#]/g, "");
+    const maxFractionDigits = cleanedFraction.length;
+    const minFractionDigits = (fractionPattern.match(/0/g) ?? []).length;
+    const negative = value < 0 || Object.is(value, -0);
+    const absolute = Math.abs(value);
+    let integerPart = "";
+    let fractionPart = "";
+    if (maxFractionDigits > 0) {
+        const fixed = absolute.toFixed(maxFractionDigits);
+        const [intSegment, fracSegment = ""] = fixed.split(".");
+        integerPart = intSegment;
+        fractionPart = fracSegment;
+        while (fractionPart.length > minFractionDigits && fractionPart.endsWith("0")) {
+            fractionPart = fractionPart.slice(0, -1);
+        }
+    }
+    else {
+        integerPart = Math.round(absolute).toString();
+    }
+    const minInteger = Math.max(minIntegerDigits, 1);
+    integerPart = integerPart.padStart(minInteger, "0");
+    if (groupingChar && groupingSize > 0) {
+        const regex = new RegExp(`\\B(?=(\\d{${groupingSize}})+(?!\\d))`, "g");
+        integerPart = integerPart.replace(regex, groupingChar);
+    }
+    let formatted = integerPart;
+    if (fractionPart.length > 0) {
+        const decimalOutput = decimalChar || ".";
+        formatted += `${decimalOutput}${fractionPart}`;
+    }
+    const sign = negative && absolute !== 0 ? "-" : "";
+    return `${sign}${prefix}${formatted}${suffix}`;
+}
+export function formatBookingAmount(value, settings) {
+    const parsed = parseAmount(value);
+    if (parsed === null) {
+        return value;
+    }
+    return formatNumberWithPattern(parsed, settings.booking_amount_display_format);
+}
+export function formatTransactionsForDisplay(entries, settings) {
+    return entries.map((tx) => ({
+        ...tx,
+        booking_date: formatTransactionDate(tx, settings),
+    }));
+}

--- a/dist/mappingUI.js
+++ b/dist/mappingUI.js
@@ -37,9 +37,6 @@ export function buildMappingUI(container, headers, initialMapping) {
         booking_type: [],
         booking_amount: [],
         booking_date_parse_format: initialMapping?.booking_date_parse_format ?? "",
-        booking_date_display_format: initialMapping?.booking_date_display_format ??
-            initialMapping?.booking_date_parse_format ??
-            "",
     };
     const entries = {};
     function updateSelectOptions(select, values) {
@@ -160,23 +157,7 @@ export function buildMappingUI(container, headers, initialMapping) {
     });
     parseWrapper.appendChild(parseLabel);
     parseWrapper.appendChild(parseInput);
-    const displayWrapper = document.createElement("div");
-    displayWrapper.className = "mapping-field";
-    const displayLabel = document.createElement("label");
-    displayLabel.textContent = "Datumsformat (Anzeige):";
-    displayLabel.htmlFor = "booking-date-display-format";
-    const displayInput = document.createElement("input");
-    displayInput.type = "text";
-    displayInput.id = "booking-date-display-format";
-    displayInput.placeholder = "z. B. dd.MM.yyyy HH:mm:ss";
-    displayInput.value = state.booking_date_display_format;
-    displayInput.addEventListener("input", () => {
-        state.booking_date_display_format = displayInput.value;
-    });
-    displayWrapper.appendChild(displayLabel);
-    displayWrapper.appendChild(displayInput);
     dateSettings.appendChild(parseWrapper);
-    dateSettings.appendChild(displayWrapper);
     container.appendChild(dateSettings);
     syncDisabledOptions();
     if (initialMapping) {
@@ -190,23 +171,16 @@ export function buildMappingUI(container, headers, initialMapping) {
             state.booking_date_parse_format = initialMapping.booking_date_parse_format;
             parseInput.value = initialMapping.booking_date_parse_format;
         }
-        if (typeof initialMapping.booking_date_display_format === "string") {
-            state.booking_date_display_format = initialMapping.booking_date_display_format;
-            displayInput.value = initialMapping.booking_date_display_format;
-        }
     }
     return {
         getMapping() {
             const parseFormat = state.booking_date_parse_format.trim();
-            const displayFormatRaw = state.booking_date_display_format.trim();
-            const displayFormat = displayFormatRaw.length > 0 ? displayFormatRaw : parseFormat;
             return {
                 booking_date: [...state.booking_date],
                 booking_text: [...state.booking_text],
                 booking_type: [...state.booking_type],
                 booking_amount: [...state.booking_amount],
                 booking_date_parse_format: parseFormat,
-                booking_date_display_format: displayFormat,
             };
         },
         setMapping(mapping) {
@@ -224,11 +198,6 @@ export function buildMappingUI(container, headers, initialMapping) {
                 : "";
             state.booking_date_parse_format = parseValue;
             parseInput.value = parseValue;
-            const displayValue = typeof mapping.booking_date_display_format === "string"
-                ? mapping.booking_date_display_format
-                : parseValue;
-            state.booking_date_display_format = displayValue;
-            displayInput.value = displayValue;
         },
         validate() {
             const missing = TARGET_FIELDS.filter((field) => state[field].length === 0);
@@ -243,9 +212,7 @@ export function buildMappingUI(container, headers, initialMapping) {
                 updateUI(field);
             });
             state.booking_date_parse_format = "";
-            state.booking_date_display_format = "";
             parseInput.value = "";
-            displayInput.value = "";
             syncDisabledOptions();
         },
     };

--- a/dist/render.js
+++ b/dist/render.js
@@ -1,4 +1,5 @@
-export function renderTable(transactions, tbody) {
+import { formatBookingAmount } from "./displaySettings.js";
+export function renderTable(transactions, tbody, displaySettings) {
     tbody.innerHTML = "";
     transactions.forEach((tx) => {
         const row = document.createElement("tr");
@@ -12,7 +13,7 @@ export function renderTable(transactions, tbody) {
         bookingType.textContent = tx.booking_type;
         row.appendChild(bookingType);
         const bookingAmount = document.createElement("td");
-        bookingAmount.textContent = tx.booking_amount;
+        bookingAmount.textContent = formatBookingAmount(tx.booking_amount, displaySettings);
         bookingAmount.className = "amount";
         row.appendChild(bookingAmount);
         tbody.appendChild(row);

--- a/dist/storage.js
+++ b/dist/storage.js
@@ -1,7 +1,9 @@
+import { sanitizeDisplaySettings } from "./displaySettings.js";
 const BANK_MAPPINGS_KEY = "bank_mappings_v1";
 const TRANSACTIONS_KEY = "transactions_unified_v1";
 const TRANSACTIONS_MASKED_KEY = "transactions_unified_masked_v1";
 const ANON_RULES_KEY = "anonymization_rules_v1";
+const DISPLAY_SETTINGS_KEY = "display_settings_v1";
 const CURRENT_RULE_VERSION = 2;
 function isStringArray(value) {
     return Array.isArray(value) && value.every((entry) => typeof entry === "string");
@@ -21,9 +23,6 @@ function toBankMapping(value) {
     const parseFormat = typeof maybe.booking_date_parse_format === "string"
         ? maybe.booking_date_parse_format
         : "";
-    const displayFormatRaw = typeof maybe.booking_date_display_format === "string"
-        ? maybe.booking_date_display_format
-        : parseFormat;
     return {
         bank_name: maybe.bank_name,
         booking_date: [...maybe.booking_date],
@@ -31,13 +30,10 @@ function toBankMapping(value) {
         booking_type: [...maybe.booking_type],
         booking_amount: [...maybe.booking_amount],
         booking_date_parse_format: parseFormat,
-        booking_date_display_format: displayFormatRaw,
     };
 }
 function sanitizeBankMapping(mapping) {
     const parseFormat = mapping.booking_date_parse_format.trim();
-    const displayFormatRaw = mapping.booking_date_display_format.trim();
-    const displayFormat = displayFormatRaw.length > 0 ? displayFormatRaw : parseFormat;
     return {
         bank_name: mapping.bank_name,
         booking_date: [...mapping.booking_date],
@@ -45,7 +41,6 @@ function sanitizeBankMapping(mapping) {
         booking_type: [...mapping.booking_type],
         booking_amount: [...mapping.booking_amount],
         booking_date_parse_format: parseFormat,
-        booking_date_display_format: displayFormat,
     };
 }
 function safeParse(text) {
@@ -81,6 +76,17 @@ export function saveBankMapping(mapping) {
         existing.push(sanitized);
     }
     localStorage.setItem(BANK_MAPPINGS_KEY, JSON.stringify(existing, null, 2));
+}
+export function loadDisplaySettings() {
+    const parsed = safeParse(localStorage.getItem(DISPLAY_SETTINGS_KEY));
+    if (parsed && typeof parsed === "object") {
+        return sanitizeDisplaySettings(parsed);
+    }
+    return sanitizeDisplaySettings(null);
+}
+export function saveDisplaySettings(settings) {
+    const sanitized = sanitizeDisplaySettings(settings);
+    localStorage.setItem(DISPLAY_SETTINGS_KEY, JSON.stringify(sanitized, null, 2));
 }
 function toUnifiedTx(value) {
     if (typeof value !== "object" || value === null) {

--- a/dist/transform.js
+++ b/dist/transform.js
@@ -1,4 +1,5 @@
 import { formatDateWithFormat, parseDateWithFormat } from "./dateFormat.js";
+import { DEFAULT_DATE_DISPLAY_FORMAT } from "./displaySettings.js";
 function createIndexMap(header) {
     const map = {};
     header.forEach((name, index) => {
@@ -36,7 +37,7 @@ function isTransactionEmpty(tx) {
         tx.booking_type.trim() === "" &&
         tx.booking_amount.trim() === "");
 }
-export function applyMapping(rows, header, mapping, bankName) {
+export function applyMapping(rows, header, mapping, bankName, displaySettings) {
     const indexMap = createIndexMap(header);
     const transactions = [];
     for (const row of rows) {
@@ -45,16 +46,17 @@ export function applyMapping(rows, header, mapping, bankName) {
         const bookingType = firstNonEmpty(mapping.booking_type.map((column) => readValue(row, column, indexMap)));
         const bookingAmount = firstNonEmpty(mapping.booking_amount.map((column) => readValue(row, column, indexMap)));
         const parseFormat = mapping.booking_date_parse_format?.trim() ?? "";
-        const displayFormat = mapping.booking_date_display_format?.trim() ?? "";
+        const displayFormatRaw = displaySettings.booking_date_display_format?.trim() ?? "";
+        const displayFormat = displayFormatRaw.length > 0 ? displayFormatRaw : DEFAULT_DATE_DISPLAY_FORMAT;
         let bookingDateFormatted = bookingDateRaw;
         let bookingDateIso = null;
         if (parseFormat && bookingDateRaw.length > 0) {
             const parsed = parseDateWithFormat(bookingDateRaw, parseFormat);
             if (parsed) {
                 bookingDateIso = parsed.toISOString();
-                const effectiveDisplayFormat = displayFormat.length > 0 ? displayFormat : parseFormat;
-                bookingDateFormatted = effectiveDisplayFormat
-                    ? formatDateWithFormat(parsed, effectiveDisplayFormat)
+                const targetFormat = displayFormat.length > 0 ? displayFormat : parseFormat;
+                bookingDateFormatted = targetFormat
+                    ? formatDateWithFormat(parsed, targetFormat)
                     : bookingDateRaw;
             }
         }

--- a/index.html
+++ b/index.html
@@ -40,6 +40,27 @@
 
       <details class="collapsible-section" open>
         <summary>
+          <h2>Anzeigeeinstellungen</h2>
+        </summary>
+        <div class="collapsible-content">
+          <label for="dateDisplayFormat">Datumsformat (Anzeige)</label>
+          <input
+            id="dateDisplayFormat"
+            type="text"
+            placeholder="z. B. dd.MM.yyyy HH:mm"
+          />
+          <label for="amountDisplayFormat">Betragsformat (Anzeige)</label>
+          <input id="amountDisplayFormat" type="text" placeholder="z. B. #,##0.00" />
+          <div class="button-row">
+            <button id="applyDisplaySettingsButton" type="button">
+              Anzeige aktualisieren
+            </button>
+          </div>
+        </div>
+      </details>
+
+      <details class="collapsible-section" open>
+        <summary>
           <h2>Anonymisierungsregeln</h2>
         </summary>
         <div class="collapsible-content">

--- a/src/displaySettings.ts
+++ b/src/displaySettings.ts
@@ -1,0 +1,219 @@
+import { formatDateWithFormat } from "./dateFormat.js";
+import { DisplaySettings, UnifiedTx } from "./types.js";
+
+export const DEFAULT_DATE_DISPLAY_FORMAT = "dd.MM.yyyy HH:mm";
+export const DEFAULT_AMOUNT_DISPLAY_FORMAT = "#,##0.00";
+
+export function sanitizeDisplaySettings(
+  value: Partial<DisplaySettings> | null | undefined
+): DisplaySettings {
+  const rawDate =
+    typeof value?.booking_date_display_format === "string"
+      ? value.booking_date_display_format
+      : "";
+  const rawAmount =
+    typeof value?.booking_amount_display_format === "string"
+      ? value.booking_amount_display_format
+      : "";
+
+  const trimmedDate = rawDate.trim();
+  const trimmedAmount = rawAmount.trim();
+
+  return {
+    booking_date_display_format:
+      trimmedDate.length > 0 ? trimmedDate : DEFAULT_DATE_DISPLAY_FORMAT,
+    booking_amount_display_format:
+      trimmedAmount.length > 0 ? trimmedAmount : DEFAULT_AMOUNT_DISPLAY_FORMAT,
+  };
+}
+
+function isValidDate(date: Date): boolean {
+  return Number.isFinite(date.getTime());
+}
+
+export function formatTransactionDate(
+  tx: UnifiedTx,
+  settings: DisplaySettings
+): string {
+  if (tx.booking_date_iso) {
+    const parsed = new Date(tx.booking_date_iso);
+    if (isValidDate(parsed)) {
+      return formatDateWithFormat(parsed, settings.booking_date_display_format);
+    }
+  }
+
+  const fallback = tx.booking_date_raw ?? tx.booking_date ?? "";
+  return fallback;
+}
+
+function parseAmount(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  let sanitized = trimmed.replace(/[\s'\u00A0]/g, "");
+  const lastComma = sanitized.lastIndexOf(",");
+  const lastDot = sanitized.lastIndexOf(".");
+  let decimalSeparator = "";
+
+  if (lastComma > lastDot) {
+    decimalSeparator = ",";
+  } else if (lastDot > lastComma) {
+    decimalSeparator = ".";
+  }
+
+  let result = "";
+  const decimalIndex =
+    decimalSeparator === "," ? lastComma : decimalSeparator === "." ? lastDot : -1;
+
+  for (let index = 0; index < sanitized.length; index += 1) {
+    const char = sanitized[index];
+    if (index === 0 && (char === "-" || char === "+")) {
+      if (char === "-") {
+        result += "-";
+      }
+      continue;
+    }
+    if (char === decimalSeparator) {
+      if (index === decimalIndex) {
+        result += ".";
+      }
+      continue;
+    }
+    if (char === "," || char === ".") {
+      continue;
+    }
+    if (/\d/.test(char)) {
+      result += char;
+    }
+  }
+
+  if (result === "" || result === "-") {
+    return null;
+  }
+
+  const parsed = Number.parseFloat(result);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function formatNumberWithPattern(value: number, pattern: string): string {
+  const trimmedPattern = pattern.trim();
+  if (!trimmedPattern) {
+    return value.toString();
+  }
+
+  const firstDigitIndex = trimmedPattern.search(/[0#]/);
+  if (firstDigitIndex === -1) {
+    return value.toString();
+  }
+
+  const lastDigitIndex =
+    trimmedPattern.length -
+    1 -
+    trimmedPattern
+      .split("")
+      .reverse()
+      .findIndex((char) => char === "0" || char === "#");
+
+  const prefix = trimmedPattern.slice(0, firstDigitIndex);
+  const suffix = trimmedPattern.slice(lastDigitIndex + 1);
+  const corePattern = trimmedPattern.slice(firstDigitIndex, lastDigitIndex + 1);
+
+  const decimalPos = Math.max(corePattern.lastIndexOf("."), corePattern.lastIndexOf(","));
+  let integerPattern = corePattern;
+  let fractionPattern = "";
+  let decimalChar = "";
+
+  if (decimalPos >= 0) {
+    decimalChar = corePattern[decimalPos];
+    integerPattern = corePattern.slice(0, decimalPos);
+    fractionPattern = corePattern.slice(decimalPos + 1);
+  }
+
+  let groupingChar = "";
+  for (let index = integerPattern.length - 1; index >= 0; index -= 1) {
+    const char = integerPattern[index];
+    if (char !== "#" && char !== "0") {
+      groupingChar = char;
+      break;
+    }
+  }
+
+  let groupingSize = 0;
+  if (groupingChar) {
+    for (let index = integerPattern.length - 1; index >= 0; index -= 1) {
+      const char = integerPattern[index];
+      if (char === "#" || char === "0") {
+        groupingSize += 1;
+      } else if (char === groupingChar) {
+        break;
+      }
+    }
+  }
+
+  const minIntegerDigits = (integerPattern.match(/0/g) ?? []).length;
+  const cleanedFraction = fractionPattern.replace(/[^0#]/g, "");
+  const maxFractionDigits = cleanedFraction.length;
+  const minFractionDigits = (fractionPattern.match(/0/g) ?? []).length;
+
+  const negative = value < 0 || Object.is(value, -0);
+  const absolute = Math.abs(value);
+
+  let integerPart = "";
+  let fractionPart = "";
+
+  if (maxFractionDigits > 0) {
+    const fixed = absolute.toFixed(maxFractionDigits);
+    const [intSegment, fracSegment = ""] = fixed.split(".");
+    integerPart = intSegment;
+    fractionPart = fracSegment;
+    while (fractionPart.length > minFractionDigits && fractionPart.endsWith("0")) {
+      fractionPart = fractionPart.slice(0, -1);
+    }
+  } else {
+    integerPart = Math.round(absolute).toString();
+  }
+
+  const minInteger = Math.max(minIntegerDigits, 1);
+  integerPart = integerPart.padStart(minInteger, "0");
+
+  if (groupingChar && groupingSize > 0) {
+    const regex = new RegExp(`\\B(?=(\\d{${groupingSize}})+(?!\\d))`, "g");
+    integerPart = integerPart.replace(regex, groupingChar);
+  }
+
+  let formatted = integerPart;
+  if (fractionPart.length > 0) {
+    const decimalOutput = decimalChar || ".";
+    formatted += `${decimalOutput}${fractionPart}`;
+  }
+
+  const sign = negative && absolute !== 0 ? "-" : "";
+  return `${sign}${prefix}${formatted}${suffix}`;
+}
+
+export function formatBookingAmount(
+  value: string,
+  settings: DisplaySettings
+): string {
+  const parsed = parseAmount(value);
+  if (parsed === null) {
+    return value;
+  }
+  return formatNumberWithPattern(parsed, settings.booking_amount_display_format);
+}
+
+export function formatTransactionsForDisplay(
+  entries: UnifiedTx[],
+  settings: DisplaySettings
+): UnifiedTx[] {
+  return entries.map((tx) => ({
+    ...tx,
+    booking_date: formatTransactionDate(tx, settings),
+  }));
+}

--- a/src/mappingUI.ts
+++ b/src/mappingUI.ts
@@ -58,10 +58,6 @@ export function buildMappingUI(
     booking_type: [],
     booking_amount: [],
     booking_date_parse_format: initialMapping?.booking_date_parse_format ?? "",
-    booking_date_display_format:
-      initialMapping?.booking_date_display_format ??
-      initialMapping?.booking_date_parse_format ??
-      "",
   };
 
   const entries: Record<
@@ -202,24 +198,7 @@ export function buildMappingUI(
   parseWrapper.appendChild(parseLabel);
   parseWrapper.appendChild(parseInput);
 
-  const displayWrapper = document.createElement("div");
-  displayWrapper.className = "mapping-field";
-  const displayLabel = document.createElement("label");
-  displayLabel.textContent = "Datumsformat (Anzeige):";
-  displayLabel.htmlFor = "booking-date-display-format";
-  const displayInput = document.createElement("input");
-  displayInput.type = "text";
-  displayInput.id = "booking-date-display-format";
-  displayInput.placeholder = "z. B. dd.MM.yyyy HH:mm:ss";
-  displayInput.value = state.booking_date_display_format;
-  displayInput.addEventListener("input", () => {
-    state.booking_date_display_format = displayInput.value;
-  });
-  displayWrapper.appendChild(displayLabel);
-  displayWrapper.appendChild(displayInput);
-
   dateSettings.appendChild(parseWrapper);
-  dateSettings.appendChild(displayWrapper);
   container.appendChild(dateSettings);
 
   syncDisabledOptions();
@@ -235,24 +214,17 @@ export function buildMappingUI(
       state.booking_date_parse_format = initialMapping.booking_date_parse_format;
       parseInput.value = initialMapping.booking_date_parse_format;
     }
-    if (typeof initialMapping.booking_date_display_format === "string") {
-      state.booking_date_display_format = initialMapping.booking_date_display_format;
-      displayInput.value = initialMapping.booking_date_display_format;
-    }
   }
 
   return {
     getMapping(): MappingResult {
       const parseFormat = state.booking_date_parse_format.trim();
-      const displayFormatRaw = state.booking_date_display_format.trim();
-      const displayFormat = displayFormatRaw.length > 0 ? displayFormatRaw : parseFormat;
       return {
         booking_date: [...state.booking_date],
         booking_text: [...state.booking_text],
         booking_type: [...state.booking_type],
         booking_amount: [...state.booking_amount],
         booking_date_parse_format: parseFormat,
-        booking_date_display_format: displayFormat,
       };
     },
     setMapping(mapping: Partial<MappingResult>) {
@@ -270,13 +242,6 @@ export function buildMappingUI(
           : "";
       state.booking_date_parse_format = parseValue;
       parseInput.value = parseValue;
-
-      const displayValue =
-        typeof mapping.booking_date_display_format === "string"
-          ? mapping.booking_date_display_format
-          : parseValue;
-      state.booking_date_display_format = displayValue;
-      displayInput.value = displayValue;
     },
     validate() {
       const missing: (keyof MappingResult)[] = TARGET_FIELDS.filter(
@@ -293,9 +258,7 @@ export function buildMappingUI(
         updateUI(field);
       });
       state.booking_date_parse_format = "";
-      state.booking_date_display_format = "";
       parseInput.value = "";
-      displayInput.value = "";
       syncDisabledOptions();
     },
   };

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,11 @@
-import { UnifiedTx } from "./types.js";
+import { formatBookingAmount } from "./displaySettings.js";
+import { DisplaySettings, UnifiedTx } from "./types.js";
 
-export function renderTable(transactions: UnifiedTx[], tbody: HTMLTableSectionElement): void {
+export function renderTable(
+  transactions: UnifiedTx[],
+  tbody: HTMLTableSectionElement,
+  displaySettings: DisplaySettings
+): void {
   tbody.innerHTML = "";
 
   transactions.forEach((tx) => {
@@ -19,7 +24,10 @@ export function renderTable(transactions: UnifiedTx[], tbody: HTMLTableSectionEl
     row.appendChild(bookingType);
 
     const bookingAmount = document.createElement("td");
-    bookingAmount.textContent = tx.booking_amount;
+    bookingAmount.textContent = formatBookingAmount(
+      tx.booking_amount,
+      displaySettings
+    );
     bookingAmount.className = "amount";
     row.appendChild(bookingAmount);
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,5 +1,6 @@
 import { formatDateWithFormat, parseDateWithFormat } from "./dateFormat.js";
-import { BankMapping, UnifiedTx } from "./types.js";
+import { DEFAULT_DATE_DISPLAY_FORMAT } from "./displaySettings.js";
+import { BankMapping, DisplaySettings, UnifiedTx } from "./types.js";
 
 type MappingSelection = Omit<BankMapping, "bank_name">;
 
@@ -51,7 +52,8 @@ export function applyMapping(
   rows: string[][],
   header: string[],
   mapping: MappingSelection,
-  bankName: string
+  bankName: string,
+  displaySettings: DisplaySettings
 ): UnifiedTx[] {
   const indexMap = createIndexMap(header);
   const transactions: UnifiedTx[] = [];
@@ -65,7 +67,9 @@ export function applyMapping(
     const bookingAmount = firstNonEmpty(mapping.booking_amount.map((column) => readValue(row, column, indexMap)));
 
     const parseFormat = mapping.booking_date_parse_format?.trim() ?? "";
-    const displayFormat = mapping.booking_date_display_format?.trim() ?? "";
+    const displayFormatRaw = displaySettings.booking_date_display_format?.trim() ?? "";
+    const displayFormat =
+      displayFormatRaw.length > 0 ? displayFormatRaw : DEFAULT_DATE_DISPLAY_FORMAT;
 
     let bookingDateFormatted = bookingDateRaw;
     let bookingDateIso: string | null = null;
@@ -74,9 +78,9 @@ export function applyMapping(
       const parsed = parseDateWithFormat(bookingDateRaw, parseFormat);
       if (parsed) {
         bookingDateIso = parsed.toISOString();
-        const effectiveDisplayFormat = displayFormat.length > 0 ? displayFormat : parseFormat;
-        bookingDateFormatted = effectiveDisplayFormat
-          ? formatDateWithFormat(parsed, effectiveDisplayFormat)
+        const targetFormat = displayFormat.length > 0 ? displayFormat : parseFormat;
+        bookingDateFormatted = targetFormat
+          ? formatDateWithFormat(parsed, targetFormat)
           : bookingDateRaw;
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,6 @@ export interface BankMapping {
   booking_type: string[];
   booking_amount: string[];
   booking_date_parse_format: string;
-  booking_date_display_format: string;
 }
 
 export interface UnifiedTx {
@@ -16,6 +15,11 @@ export interface UnifiedTx {
   booking_text: string;
   booking_type: string;
   booking_amount: string;
+}
+
+export interface DisplaySettings {
+  booking_date_display_format: string;
+  booking_amount_display_format: string;
 }
 
 export type AnonRule =


### PR DESCRIPTION
## Summary
- add a dedicated display settings section so users can adjust booking date and amount formats for the overview table
- introduce shared formatting helpers and apply them during import, rendering, and refreshes to keep stored data in sync
- persist the chosen formats in local storage and wire an update button that reapplies the settings to saved transactions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de412a8cbc8333948b7d2196d1129b