### PR TITLE
Add token authentication workflow

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -8,9 +8,18 @@ import { applyAnonymization } from "./anonymize.js";
 import { buildRulesUI } from "./rulesUI.js";
 import { formatBookingAmount, formatTransactionsForDisplay, sanitizeDisplaySettings, } from "./displaySettings.js";
 import { formatDateWithFormat, parseDateWithFormat } from "./dateFormat.js";
+import * as auth from "./auth.js";
 const CONFIG_MAPPING_KEY = "mapping_to_target_schema";
 const CONFIG_DISPLAY_KEY = "display_settings";
 const CONFIG_RULES_KEY = "anonymization_rules";
+const mainElement = document.querySelector("main");
+const tokenLoginContainer = document.getElementById("tokenLoginContainer");
+const tokenForm = document.getElementById("tokenLogin");
+const tokenInputField = document.getElementById("tokenLoginForm");
+const tokenErrorElement = document.getElementById("tokenError");
+const tokenSubmitButton = tokenForm?.querySelector('button[type="submit"]');
+const requestTokenButton = document.getElementById("requestTokenButton");
+const logoutButton = document.getElementById("logoutButton");
 const fileInput = document.getElementById("csvInput");
 const bankNameInput = document.getElementById("bankName");
 const mappingContainer = document.getElementById("mappingContainer");
@@ -37,6 +46,7 @@ let anonymizedActive = false;
 let anonymizedCache = [];
 let lastAnonymizationWarnings = [];
 let displaySettings = loadDisplaySettings();
+let appInitialized = false;
 function getConfiguredRules() {
     if (rulesController) {
         return rulesController.getRules();
@@ -50,6 +60,14 @@ function assertElement(value, message) {
     }
     return value;
 }
+const ensuredMainElement = assertElement(mainElement, "Hauptbereich nicht gefunden");
+const ensuredTokenLoginContainer = assertElement(tokenLoginContainer, "Token-Anmeldecontainer nicht gefunden");
+const ensuredTokenForm = assertElement(tokenForm, "Token-Anmeldeformular fehlt");
+const ensuredTokenInput = assertElement(tokenInputField, "Token Eingabefeld fehlt");
+const ensuredTokenError = assertElement(tokenErrorElement, "Token Fehlermeldungsbereich fehlt");
+const ensuredTokenSubmitButton = assertElement(tokenSubmitButton, "Token Absenden Button fehlt");
+const ensuredRequestTokenButton = assertElement(requestTokenButton, "Token anfordern Button fehlt");
+const ensuredLogoutButton = assertElement(logoutButton, "Logout Button fehlt");
 const ensuredFileInput = assertElement(fileInput, "CSV Eingabefeld nicht gefunden");
 const ensuredBankNameInput = assertElement(bankNameInput, "Banknamenfeld nicht gefunden");
 const ensuredMappingContainer = assertElement(mappingContainer, "Mapping-Container nicht gefunden");
@@ -73,6 +91,147 @@ ensuredAmountDisplayFormatInput.value = displaySettings.booking_amount_display_f
 function setStatus(message, type = "info") {
     ensuredStatusArea.textContent = message;
     ensuredStatusArea.setAttribute("data-status", type);
+}
+function clearTokenError() {
+    ensuredTokenError.textContent = "";
+    ensuredTokenError.hidden = true;
+}
+function setTokenError(message) {
+    ensuredTokenError.textContent = message;
+    ensuredTokenError.hidden = false;
+}
+function showLogin(message) {
+    ensuredMainElement.hidden = true;
+    ensuredTokenLoginContainer.hidden = false;
+    if (message) {
+        setTokenError(message);
+    }
+    else {
+        clearTokenError();
+    }
+    ensuredTokenInput.focus();
+}
+function showMain() {
+    ensuredTokenLoginContainer.hidden = true;
+    ensuredMainElement.hidden = false;
+    clearTokenError();
+}
+function setTokenFormDisabled(disabled) {
+    ensuredTokenInput.disabled = disabled;
+    ensuredTokenSubmitButton.disabled = disabled;
+    ensuredRequestTokenButton.disabled = disabled;
+}
+function handleLogout() {
+    auth.deleteTokenCookie();
+    anonymizedActive = false;
+    anonymizedCache = [];
+    transactions = [];
+    detectedHeader = null;
+    renderTransactions([]);
+    ensuredAnonymizeButton.textContent = "Anonymisieren";
+    ensuredSaveMaskedButton.disabled = true;
+    ensuredTokenInput.value = "";
+    setStatus("Bitte melden Sie sich erneut an.", "info");
+    showLogin("Sie wurden abgemeldet.");
+}
+function setupAuthUI() {
+    ensuredTokenForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        void handleTokenSubmission();
+    });
+    ensuredRequestTokenButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        void handleTokenRequest();
+    });
+    ensuredLogoutButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        handleLogout();
+    });
+}
+async function handleTokenSubmission() {
+    clearTokenError();
+    const rawToken = ensuredTokenInput.value.trim();
+    if (!rawToken) {
+        setTokenError("Bitte geben Sie ein Token ein.");
+        return;
+    }
+    setTokenFormDisabled(true);
+    try {
+        const result = await auth.validateToken(rawToken);
+        ensuredTokenInput.value = "";
+        handleAuthenticated(result.message ?? "Authentifizierung erfolgreich.");
+    }
+    catch (error) {
+        if (error instanceof auth.AuthError) {
+            setTokenError(error.message);
+        }
+        else if (error instanceof Error) {
+            setTokenError(error.message);
+        }
+        else {
+            setTokenError("Unbekannter Fehler bei der Anmeldung.");
+        }
+    }
+    finally {
+        setTokenFormDisabled(false);
+    }
+}
+async function handleTokenRequest() {
+    clearTokenError();
+    setTokenFormDisabled(true);
+    try {
+        const result = await auth.requestNewToken();
+        ensuredTokenInput.value = "";
+        handleAuthenticated(result.message ?? "Es wurde ein neues Token erstellt und gespeichert.");
+    }
+    catch (error) {
+        if (error instanceof auth.AuthError) {
+            setTokenError(error.message);
+        }
+        else if (error instanceof Error) {
+            setTokenError(error.message);
+        }
+        else {
+            setTokenError("Neues Token konnte nicht angefordert werden.");
+        }
+    }
+    finally {
+        setTokenFormDisabled(false);
+    }
+}
+function hydrateTransactionsFromStorage() {
+    transactions = loadTransactions();
+    anonymizedActive = false;
+    anonymizedCache = [];
+    lastAnonymizationWarnings = [];
+    renderTransactions(transactions);
+    ensuredAnonymizeButton.textContent = "Anonymisieren";
+    ensuredSaveMaskedButton.disabled = true;
+    const masked = loadMaskedTransactions();
+    if (masked.length > 0) {
+        setStatus("Es sind bereits anonymisierte Daten gespeichert.", "info");
+    }
+}
+function hydrateRulesFromStorage() {
+    if (!rulesController) {
+        return;
+    }
+    const { rules } = loadAnonymizationRules();
+    rulesController.setRules(rules);
+}
+function handleAuthenticated(message) {
+    if (!appInitialized) {
+        init();
+        appInitialized = true;
+    }
+    else {
+        hydrateTransactionsFromStorage();
+        hydrateRulesFromStorage();
+    }
+    showMain();
+    if (message) {
+        setStatus(message, "info");
+    }
 }
 function createTimestampedFilename(base, extension) {
     const datePart = new Date().toISOString().slice(0, 10);
@@ -616,12 +775,7 @@ function handleApplySingleRule(rule) {
     }
 }
 function init() {
-    transactions = loadTransactions();
-    renderTransactions(transactions);
-    const masked = loadMaskedTransactions();
-    if (masked.length > 0) {
-        setStatus("Es sind bereits anonymisierte Daten gespeichert.", "info");
-    }
+    hydrateTransactionsFromStorage();
     ensuredFileInput.addEventListener("change", (event) => {
         const input = event.currentTarget;
         const file = input.files?.[0];
@@ -672,8 +826,7 @@ function init() {
         input.value = "";
     });
     rulesController = buildRulesUI(ensuredRulesContainer);
-    const { rules } = loadAnonymizationRules();
-    rulesController.setRules(rules);
+    hydrateRulesFromStorage();
     ensuredRulesContainer.addEventListener("ruleapply", (event) => {
         const customEvent = event;
         if (customEvent.detail) {
@@ -685,4 +838,27 @@ function init() {
         handleSaveRules();
     });
 }
-init();
+async function bootstrap() {
+    setupAuthUI();
+    try {
+        await auth.ensureAuthenticated();
+        handleAuthenticated();
+    }
+    catch (error) {
+        if (error instanceof auth.AuthError) {
+            if (error.code === "NO_TOKEN") {
+                showLogin();
+            }
+            else {
+                showLogin(error.message);
+            }
+        }
+        else if (error instanceof Error) {
+            showLogin(error.message);
+        }
+        else {
+            showLogin("Authentifizierung fehlgeschlagen.");
+        }
+    }
+}
+void bootstrap();

--- a/dist/auth.js
+++ b/dist/auth.js
@@ -1,0 +1,128 @@
+const TOKEN_COOKIE_NAME = "umsatz_token";
+const TOKEN_ENDPOINT = "/auth/token";
+export class AuthError extends Error {
+    constructor(code, message) {
+        super(message);
+        this.name = "AuthError";
+        this.code = code;
+    }
+}
+function readCookie(name) {
+    const cookieString = document.cookie;
+    if (!cookieString) {
+        return null;
+    }
+    const cookies = cookieString.split(";");
+    for (const cookie of cookies) {
+        const [cookieName, ...rest] = cookie.trim().split("=");
+        if (cookieName === name) {
+            return decodeURIComponent(rest.join("="));
+        }
+    }
+    return null;
+}
+function resolveMaxAge(result) {
+    if (typeof result.maxAge === "number") {
+        return result.maxAge;
+    }
+    if (typeof result.expiresIn === "number") {
+        return result.expiresIn;
+    }
+    if (typeof result.expires_in === "number") {
+        return result.expires_in;
+    }
+    return undefined;
+}
+export function getTokenCookie() {
+    return readCookie(TOKEN_COOKIE_NAME);
+}
+export function setTokenCookie(token, maxAgeSeconds) {
+    const parts = [
+        `${TOKEN_COOKIE_NAME}=${encodeURIComponent(token)}`,
+        "Path=/",
+        "Secure",
+        "SameSite=Strict",
+    ];
+    if (typeof maxAgeSeconds === "number" && Number.isFinite(maxAgeSeconds)) {
+        const maxAge = Math.max(0, Math.floor(maxAgeSeconds));
+        parts.push(`Max-Age=${maxAge}`);
+    }
+    document.cookie = parts.join("; ");
+}
+export function deleteTokenCookie() {
+    document.cookie = `${TOKEN_COOKIE_NAME}=; Path=/; Max-Age=0; Secure; SameSite=Strict`;
+}
+async function callTokenEndpoint(payload) {
+    let response;
+    try {
+        response = await fetch(TOKEN_ENDPOINT, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+            credentials: "include",
+        });
+    }
+    catch {
+        throw new AuthError("NETWORK_ERROR", "Verbindung zum Authentifizierungsdienst fehlgeschlagen.");
+    }
+    let result;
+    if (response.status !== 204) {
+        try {
+            result = (await response.json());
+        }
+        catch {
+            if (response.ok) {
+                // If we received a non-JSON response but the request was OK, treat it as valid.
+                result = { valid: true };
+            }
+            else {
+                throw new AuthError("INVALID_TOKEN", "Antwort des Authentifizierungsdienstes konnte nicht gelesen werden.");
+            }
+        }
+    }
+    else {
+        result = { valid: response.ok };
+    }
+    if (!response.ok) {
+        const message = result?.message ?? `Token konnte nicht validiert werden (Status ${response.status}).`;
+        throw new AuthError("INVALID_TOKEN", message);
+    }
+    return result ?? { valid: true };
+}
+export async function validateToken(token) {
+    if (!token) {
+        throw new AuthError("INVALID_TOKEN", "Es wurde kein Token übermittelt.");
+    }
+    const result = await callTokenEndpoint({ token });
+    const isValid = result.valid ?? true;
+    if (!isValid) {
+        throw new AuthError("INVALID_TOKEN", result.message ?? "Das Token ist ungültig oder abgelaufen.");
+    }
+    const resolvedToken = result.token ?? token;
+    const maxAge = resolveMaxAge(result);
+    setTokenCookie(resolvedToken, maxAge);
+    return {
+        token: resolvedToken,
+        message: result.message,
+    };
+}
+export async function ensureAuthenticated() {
+    const token = getTokenCookie();
+    if (!token) {
+        throw new AuthError("NO_TOKEN", "Kein Zugriffstoken gefunden.");
+    }
+    const result = await validateToken(token);
+    return result.token;
+}
+export async function requestNewToken() {
+    const result = await callTokenEndpoint({ action: "generate" });
+    if (!result.token) {
+        throw new AuthError("INVALID_TOKEN", result.message ?? "Es wurde kein neues Token bereitgestellt.");
+    }
+    const maxAge = resolveMaxAge(result);
+    setTokenCookie(result.token, maxAge);
+    return {
+        token: result.token,
+        message: result.message,
+    };
+}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js" defer></script>
     <script type="module" src="./dist/app.js"></script>
   </head>
-  <body>
+  <body data-auth-endpoint="https://umsatz-anonymizer-auth.onrender.com/auth/token">
     <section id="tokenLoginContainer">
       <form id="tokenLogin" autocomplete="off">
         <h1>Umsatz Anonymizer</h1>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,23 @@
     <script type="module" src="./dist/app.js"></script>
   </head>
   <body>
-    <main>
+    <section id="tokenLoginContainer">
+      <form id="tokenLogin" autocomplete="off">
+        <h1>Umsatz Anonymizer</h1>
+        <p>Bitte geben Sie Ihr Zugriffstoken ein, um das Tool zu verwenden.</p>
+        <label for="tokenLoginForm">Token</label>
+        <input id="tokenLoginForm" type="password" required />
+        <div class="button-row">
+          <button type="submit">Anmelden</button>
+          <button id="requestTokenButton" type="button">Neues Token anfordern</button>
+        </div>
+        <p id="tokenError" role="alert" hidden></p>
+      </form>
+    </section>
+    <main hidden>
+      <div class="button-row align-right">
+        <button id="logoutButton" type="button">Abmelden</button>
+      </div>
       <h1>Umsätze importieren &amp; anonymisieren</h1>
 
       <details class="collapsible-section" open>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js" defer></script>
     <script type="module" src="./dist/app.js"></script>
   </head>
-  <body data-auth-endpoint="https://umsatz-anonymizer-auth.onrender.com/auth/token">
+  <body data-auth-endpoint="https://umsatz-api.onrender.com/auth/token">
     <section id="tokenLoginContainer">
       <form id="tokenLogin" autocomplete="off">
         <h1>Umsatz Anonymizer</h1>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "test": "npm run build"
+    "test": "npm run build",
+    "start:auth": "node server/index.js"
   },
   "devDependencies": {
     "typescript": "^5.4.0"

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,207 @@
+const { createServer } = require("node:http");
+const { randomBytes } = require("node:crypto");
+const { URL } = require("node:url");
+
+const PORT = parseInt(process.env.PORT ?? "3000", 10);
+const TOKEN_COOKIE_NAME = process.env.TOKEN_COOKIE_NAME ?? "umsatz_token";
+const TOKEN_TTL_SECONDS = Math.max(
+  60,
+  parseInt(process.env.AUTH_TOKEN_TTL ?? "86400", 10) || 86400,
+);
+const STATIC_TOKEN = process.env.AUTH_TOKEN?.trim();
+
+/** @type {Map<string, number>} */
+const generatedTokens = new Map();
+
+function cleanupExpiredTokens() {
+  const now = Date.now();
+  for (const [token, expiresAt] of generatedTokens.entries()) {
+    if (expiresAt <= now) {
+      generatedTokens.delete(token);
+    }
+  }
+}
+
+function ttlFor(token) {
+  cleanupExpiredTokens();
+  if (STATIC_TOKEN && token === STATIC_TOKEN) {
+    return TOKEN_TTL_SECONDS;
+  }
+  const expiresAt = generatedTokens.get(token);
+  if (!expiresAt) {
+    return null;
+  }
+  const ttlMs = expiresAt - Date.now();
+  if (ttlMs <= 0) {
+    generatedTokens.delete(token);
+    return null;
+  }
+  return Math.max(1, Math.floor(ttlMs / 1000));
+}
+
+function rememberToken(token) {
+  generatedTokens.set(token, Date.now() + TOKEN_TTL_SECONDS * 1000);
+}
+
+function generateToken() {
+  return randomBytes(32).toString("base64url");
+}
+
+function jsonResponse(res, statusCode, body, cookie) {
+  res.statusCode = statusCode;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.setHeader("Cache-Control", "no-store");
+  if (cookie) {
+    res.setHeader("Set-Cookie", cookie);
+  }
+  res.end(JSON.stringify(body));
+}
+
+function buildCookie(token, maxAgeSeconds) {
+  const maxAge = Math.max(1, maxAgeSeconds ?? TOKEN_TTL_SECONDS);
+  const parts = [
+    `${TOKEN_COOKIE_NAME}=${token}`,
+    `Path=/`,
+    `Max-Age=${maxAge}`,
+    `HttpOnly`,
+    `Secure`,
+    `SameSite=Strict`,
+  ];
+  return parts.join("; ");
+}
+
+async function readJson(req) {
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+  }
+  if (chunks.length === 0) {
+    return {};
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    throw new Error("INVALID_JSON");
+  }
+}
+
+function handleTokenRequest(req, res) {
+  readJson(req)
+    .then((payload) => {
+      const { action, token } = payload ?? {};
+
+      if (action === "generate") {
+        const newToken = generateToken();
+        rememberToken(newToken);
+        const cookie = buildCookie(newToken, TOKEN_TTL_SECONDS);
+        return jsonResponse(
+          res,
+          201,
+          {
+            token: newToken,
+            valid: true,
+            maxAge: TOKEN_TTL_SECONDS,
+            message: "Neues Token erstellt.",
+          },
+          cookie,
+        );
+      }
+
+      if (typeof token !== "string" || token.trim() === "") {
+        return jsonResponse(
+          res,
+          400,
+          {
+            valid: false,
+            message: "Es wurde kein Token übermittelt.",
+          },
+        );
+      }
+
+      const trimmedToken = token.trim();
+      const remainingTtl = ttlFor(trimmedToken);
+      if (!remainingTtl) {
+        return jsonResponse(
+          res,
+          401,
+          {
+            valid: false,
+            message: "Das Token ist ungültig oder abgelaufen.",
+          },
+        );
+      }
+
+      rememberToken(trimmedToken);
+      const cookie = buildCookie(trimmedToken, TOKEN_TTL_SECONDS);
+      return jsonResponse(
+        res,
+        200,
+        {
+          token: trimmedToken,
+          valid: true,
+          maxAge: TOKEN_TTL_SECONDS,
+          message: "Token validiert.",
+        },
+        cookie,
+      );
+    })
+    .catch((error) => {
+      if (error?.message === "INVALID_JSON") {
+        return jsonResponse(
+          res,
+          400,
+          {
+            valid: false,
+            message: "Die Anfrage konnte nicht verarbeitet werden.",
+          },
+        );
+      }
+      console.error("/auth/token error", error);
+      return jsonResponse(
+        res,
+        500,
+        {
+          valid: false,
+          message: "Interner Fehler im Authentifizierungsdienst.",
+        },
+      );
+    });
+}
+
+const server = createServer((req, res) => {
+  const origin = req.headers.origin;
+  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+
+  if (req.method === "OPTIONS") {
+    res.statusCode = 204;
+    if (origin) {
+      res.setHeader("Access-Control-Allow-Origin", origin);
+    }
+    res.setHeader("Access-Control-Allow-Credentials", "true");
+    res.setHeader(
+      "Access-Control-Allow-Headers",
+      req.headers["access-control-request-headers"] ?? "content-type",
+    );
+    res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+    res.end();
+    return;
+  }
+
+  if (origin) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Access-Control-Allow-Credentials", "true");
+  }
+
+  if (req.method === "POST" && url.pathname === "/auth/token") {
+    handleTokenRequest(req, res);
+    return;
+  }
+
+  res.statusCode = 404;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify({ message: "Not Found" }));
+});
+
+server.listen(PORT, () => {
+  console.log(`Auth backend listening on http://localhost:${PORT}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,40 @@ body {
   color: #222;
 }
 
+#tokenLoginContainer {
+  max-width: 480px;
+  margin: 8vh auto 2rem;
+  padding: 2rem 1.75rem;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+#tokenLogin {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+#tokenLogin h1 {
+  margin: 0;
+}
+
+#tokenLogin p {
+  margin: 0;
+}
+
+#tokenLoginForm {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+
+#tokenError[hidden] {
+  display: none !important;
+}
+
 main {
   max-width: 960px;
   margin: 0 auto;
@@ -142,6 +176,10 @@ select[multiple] {
   flex-wrap: wrap;
   gap: 0.75rem;
   margin-top: 1rem;
+}
+
+.button-row.align-right {
+  justify-content: flex-end;
 }
 
 .rules-info {
@@ -360,6 +398,11 @@ tbody tr:nth-child(odd) {
     color: #e6e6e6;
   }
 
+  #tokenLoginContainer {
+    background: #1c1c1c;
+    box-shadow: none;
+  }
+
   section {
     background: #1c1c1c;
     box-shadow: none;
@@ -384,6 +427,12 @@ tbody tr:nth-child(odd) {
     background: #121212;
     color: inherit;
     border-color: #333;
+  }
+
+  #tokenLoginForm {
+    background: #121212;
+    border-color: #333;
+    color: inherit;
   }
 
   table {


### PR DESCRIPTION
## Summary
- add a login surface that hides the application until a token is supplied and expose a logout control
- introduce an auth helper module to manage token cookies, validation, and token generation requests
- gate the existing bootstrap on authentication and update styling for the new login view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3bd0b0bc883339c1cc75e6e14b418