### PR TITLE
Clear stored data during logout

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -3,7 +3,7 @@ import { detectHeader } from "./headerDetect.js";
 import { buildMappingUI } from "./mappingUI.js";
 import { applyMapping } from "./transform.js";
 import { renderTable } from "./render.js";
-import { appendTransactions, loadDisplaySettings, loadAnonymizationRules, loadBankMappings, importAnonymizationRules, importBankMappings, loadMaskedTransactions, loadTransactions, saveBankMapping, saveDisplaySettings, saveAnonymizationRules, saveTransactions, saveMaskedTransactions, } from "./storage.js";
+import { appendTransactions, loadDisplaySettings, loadAnonymizationRules, loadBankMappings, importAnonymizationRules, importBankMappings, loadMaskedTransactions, loadTransactions, clearPersistentData, saveBankMapping, saveDisplaySettings, saveAnonymizationRules, saveTransactions, saveMaskedTransactions, } from "./storage.js";
 import { applyAnonymization } from "./anonymize.js";
 import { buildRulesUI } from "./rulesUI.js";
 import { formatBookingAmount, formatTransactionsForDisplay, sanitizeDisplaySettings, } from "./displaySettings.js";
@@ -123,13 +123,18 @@ function setTokenFormDisabled(disabled) {
 }
 function handleLogout() {
     auth.deleteTokenCookie();
+    clearPersistentData();
     anonymizedActive = false;
     anonymizedCache = [];
+    lastAnonymizationWarnings = [];
     transactions = [];
     detectedHeader = null;
     renderTransactions([]);
     ensuredAnonymizeButton.textContent = "Anonymisieren";
     ensuredSaveMaskedButton.disabled = true;
+    displaySettings = loadDisplaySettings();
+    ensuredDateDisplayFormatInput.value = displaySettings.booking_date_display_format;
+    ensuredAmountDisplayFormatInput.value = displaySettings.booking_amount_display_format;
     ensuredTokenInput.value = "";
     setStatus("Bitte melden Sie sich erneut an.", "info");
     showLogin("Sie wurden abgemeldet.");

--- a/dist/storage.js
+++ b/dist/storage.js
@@ -316,3 +316,15 @@ export function importAnonymizationRules(raw) {
     }
     return null;
 }
+export function clearPersistentData() {
+    const keys = [
+        BANK_MAPPINGS_KEY,
+        TRANSACTIONS_KEY,
+        TRANSACTIONS_MASKED_KEY,
+        ANON_RULES_KEY,
+        DISPLAY_SETTINGS_KEY,
+    ];
+    for (const key of keys) {
+        localStorage.removeItem(key);
+    }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import {
   importBankMappings,
   loadMaskedTransactions,
   loadTransactions,
+  clearPersistentData,
   saveBankMapping,
   saveDisplaySettings,
   saveAnonymizationRules,
@@ -201,13 +202,18 @@ function setTokenFormDisabled(disabled: boolean): void {
 
 function handleLogout(): void {
   auth.deleteTokenCookie();
+  clearPersistentData();
   anonymizedActive = false;
   anonymizedCache = [];
+  lastAnonymizationWarnings = [];
   transactions = [];
   detectedHeader = null;
   renderTransactions([]);
   ensuredAnonymizeButton.textContent = "Anonymisieren";
   ensuredSaveMaskedButton.disabled = true;
+  displaySettings = loadDisplaySettings();
+  ensuredDateDisplayFormatInput.value = displaySettings.booking_date_display_format;
+  ensuredAmountDisplayFormatInput.value = displaySettings.booking_amount_display_format;
   ensuredTokenInput.value = "";
   setStatus("Bitte melden Sie sich erneut an.", "info");
   showLogin("Sie wurden abgemeldet.");

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -376,3 +376,16 @@ export function importAnonymizationRules(
 
   return null;
 }
+
+export function clearPersistentData(): void {
+  const keys = [
+    BANK_MAPPINGS_KEY,
+    TRANSACTIONS_KEY,
+    TRANSACTIONS_MASKED_KEY,
+    ANON_RULES_KEY,
+    DISPLAY_SETTINGS_KEY,
+  ];
+  for (const key of keys) {
+    localStorage.removeItem(key);
+  }
+}


### PR DESCRIPTION
## Summary
- clear application storage keys when handling logout to prevent data leakage between sessions
- reset display settings inputs after logout so the UI reflects the cleared state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e541f3f95c8333be4fda7620c721b7