### PR TITLE
Add backend API and connect frontend storage to remote data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,89 @@
+# Umsatz Anonymizer
+
+Dieses Projekt kombiniert das bestehende Frontend mit einem neuen Express-basierten Backend, um Einstellungen, Bank-Mappings und Umsätze sicher über ein Token-geschütztes API zu verwalten.
+
+## Projektüberblick
+
+- **Frontend**: Statisches TypeScript/JavaScript-Frontend (`src/`), das über `initializeStorage()` auf das Backend zugreift und alle Anfragen mit `credentials: "include"` ausführt.
+- **Backend**: Express-Anwendung unter `backend/`, die Token generiert/validiert und folgende Routen bereitstellt:
+  - `POST /auth/token`, `POST /auth/session`, `POST /auth/logout`
+  - `GET/PUT /settings`
+  - `GET/POST /transactions`
+  - `GET/POST /transactions/masked`
+  - `GET/POST /bank-mapping`
+  - `DELETE /storage`
+- **Datenbank**: PostgreSQL-Migrationen in `backend/db/001_init.sql` erzeugen Tabellen, Trigger und Funktionen (`touch_user_token`).
+
+## Entwicklung
+
+```bash
+npm install   # Installiert Abhängigkeiten (Express, pg, supertest ...)
+npm run build # Baut das Frontend
+npm run test  # Führt TypeScript-Build und node:test-Suite aus
+npm run start:backend # Startet das Backend auf PORT (Default 8080)
+```
+
+> **Hinweis:** In offline-Umgebungen schlägt `npm install` fehl. Die Tests verwenden `supertest`; ohne Installation schlägt `npm run test` entsprechend fehl.
+
+## Render.com Deployment
+
+1. **PostgreSQL-Instanz anlegen**
+   - Über das Render Dashboard eine „PostgreSQL“ Datenbank erstellen.
+   - `DATABASE_URL` (inkl. Passwort) notieren.
+   - Für SSL-Verbindungen `PGSSLMODE=require` setzen.
+
+2. **Backend-Service konfigurieren**
+   - Neuen „Web Service“ auf Render anlegen, Repository verbinden.
+   - Build Command: `npm install && npm run build`
+   - Start Command: `npm run start:backend`
+   - Environment Variables:
+     - `DATABASE_URL` – von Render bereitgestellte Verbindungs-URL
+     - `PGSSLMODE` – `require`
+     - `TOKEN_COOKIE_NAME` – optional (Default `umsatz_token`)
+     - `AUTH_TOKEN_TTL` – optional Gültigkeitsdauer der Tokens in Sekunden (Default 86400)
+     - `ALLOWED_ORIGINS` – Komma-separierte Liste der Frontend-URLs, die Cookies senden dürfen
+
+3. **Migrationen einspielen**
+   - Über Render „Shell“ oder lokal mit `psql` verbinden:
+     ```bash
+     psql "$DATABASE_URL" -f backend/db/001_init.sql
+     ```
+   - Alternativ kann eine Render „cron job“ oder ein separates Skript genutzt werden.
+
+4. **Frontend deployen**
+   - Statisches Hosting (z. B. Render Static Site) mit den Dateien aus `dist/` bzw. `index.html`.
+   - Im HTML `<head>` eine Meta-Definition ergänzen, damit das Frontend weiß, wo das Backend läuft:
+     ```html
+     <meta name="backend-base-url" content="https://<your-backend-service>.onrender.com">
+     ```
+   - Alternativ `window.BACKEND_BASE_URL` vor Laden des Bundles setzen.
+
+5. **Smoke-Test**
+   - Token über `/auth/token` generieren (Render Dashboard oder Postman).
+   - Frontend aufrufen, `initializeStorage()` lädt Einstellungen und Umsätze aus dem Backend.
+
+## Tests
+
+`backend/__tests__/app.test.js` enthält node:test-basierte Supertest-Suites, die u. a. prüfen:
+
+- Token-Generierung und Cookie-Handling
+- Authentifizierungs-Pflicht für `/settings`
+- Validierung der `/transactions`-Payloads
+
+Zum Ausführen: `npm run test` (nach erfolgreichem `npm install`).
+
+## Backend-Umgebungsvariablen
+
+| Variable             | Beschreibung                                             |
+| -------------------- | -------------------------------------------------------- |
+| `PORT`               | Port für das Express-Backend (Default 8080)              |
+| `DATABASE_URL`       | PostgreSQL-Verbindungszeichenkette                       |
+| `PGSSLMODE`          | Für Render `require`, aktiviert SSL                      |
+| `TOKEN_COOKIE_NAME`  | Name des Auth-Cookies (Default `umsatz_token`)           |
+| `AUTH_TOKEN_TTL`     | Token-Gültigkeit in Sekunden (min. 60, Default 86400)    |
+| `ALLOWED_ORIGINS`    | Komma-separierte Liste erlaubter Origins für CORS        |
+| `MAX_PAYLOAD`        | Optionales Limit für JSON-Bodies (z. B. `2mb`)           |
+
+## Hinweis zu Storage-Initialisierung
+
+Das Frontend ruft `initializeStorage()` nach erfolgreicher Authentifizierung auf. Die Funktion lädt Einstellungen, Bank-Mappings und Umsätze in einen In-Memory-Cache. Alle synchronen Storage-Methoden arbeiten gegen diesen Cache und senden Änderungen asynchron an das Backend (mit Fehler-Logging).

--- a/backend/__tests__/app.test.js
+++ b/backend/__tests__/app.test.js
@@ -1,0 +1,164 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const request = require("supertest");
+const { createApp } = require("../app.js");
+
+function createSpy(fn) {
+  const calls = [];
+  const spy = (...args) => {
+    calls.push(args);
+    return fn(...args);
+  };
+  spy.calls = calls;
+  return spy;
+}
+
+test("POST /auth/token issues a new token", async () => {
+  const createToken = createSpy(async (token) => ({
+    token,
+    created_on: "2024-01-01T00:00:00.000Z",
+    accessed_on: "2024-01-01T00:00:00.000Z",
+  }));
+  const db = {
+    createToken,
+    touchToken: async () => null,
+    tokenExists: async () => false,
+    getSettings: async () => ({}),
+    updateSettings: async () => ({}),
+    listTransactions: async () => [],
+    replaceTransactions: async () => undefined,
+    readMaskedTransactions: async () => [],
+    replaceMaskedTransactions: async () => undefined,
+    listBankMappings: async () => [],
+    upsertBankMapping: async () => undefined,
+    clearBankMappings: async () => undefined,
+    clearTransactions: async () => undefined,
+  };
+
+  const app = createApp({ db });
+  const response = await request(app)
+    .post("/auth/token")
+    .send({ action: "generate" })
+    .expect(201);
+
+  assert.equal(createToken.calls.length, 1);
+  assert.ok(response.body.token);
+  assert.equal(response.body.valid, undefined);
+  const setCookie = response.get("set-cookie");
+  assert.ok(Array.isArray(setCookie) && setCookie.some((cookie) => cookie.includes("umsatz_token")));
+});
+
+test("GET /settings requires authentication", async () => {
+  const db = {
+    createToken: async () => ({}),
+    touchToken: async () => null,
+    tokenExists: async () => false,
+    getSettings: async () => ({}),
+    updateSettings: async () => ({}),
+    listTransactions: async () => [],
+    replaceTransactions: async () => undefined,
+    readMaskedTransactions: async () => [],
+    replaceMaskedTransactions: async () => undefined,
+    listBankMappings: async () => [],
+    upsertBankMapping: async () => undefined,
+    clearBankMappings: async () => undefined,
+    clearTransactions: async () => undefined,
+  };
+
+  const app = createApp({ db });
+  await request(app).get("/settings").expect(401);
+});
+
+test("POST /transactions validates payload", async () => {
+  const replaceTransactions = createSpy(async () => undefined);
+  const db = {
+    createToken: async () => ({}),
+    touchToken: async () => ({
+      token: "test",
+      created_on: "2024-01-01T00:00:00.000Z",
+      accessed_on: "2024-01-01T00:00:00.000Z",
+    }),
+    tokenExists: async () => true,
+    getSettings: async () => ({}),
+    updateSettings: async () => ({}),
+    listTransactions: async () => [],
+    replaceTransactions,
+    readMaskedTransactions: async () => [],
+    replaceMaskedTransactions: async () => undefined,
+    listBankMappings: async () => [],
+    upsertBankMapping: async () => undefined,
+    clearBankMappings: async () => undefined,
+    clearTransactions: async () => undefined,
+  };
+
+  const app = createApp({ db });
+  await request(app)
+    .post("/transactions")
+    .set("Cookie", "umsatz_token=test")
+    .send({
+      transactions: [
+        {
+          bank_name: "Test Bank",
+          booking_text: "Payment",
+          booking_amount: "10.00",
+          booking_type: "CARD",
+          booking_date: "2024-01-01",
+          booking_date_raw: "2024-01-01",
+          booking_date_iso: null,
+          raw: "should trigger validation error",
+        },
+      ],
+    })
+    .expect(400);
+
+  assert.equal(replaceTransactions.calls.length, 0);
+});
+
+test("POST /transactions stores sanitized entries", async () => {
+  let stored = [];
+  const db = {
+    createToken: async () => ({}),
+    touchToken: async () => ({
+      token: "test",
+      created_on: "2024-01-01T00:00:00.000Z",
+      accessed_on: "2024-01-01T00:00:00.000Z",
+    }),
+    tokenExists: async () => true,
+    getSettings: async () => ({}),
+    updateSettings: async () => ({}),
+    listTransactions: async () => stored,
+    replaceTransactions: async (_token, entries) => {
+      stored = entries;
+    },
+    readMaskedTransactions: async () => [],
+    replaceMaskedTransactions: async () => undefined,
+    listBankMappings: async () => [],
+    upsertBankMapping: async () => undefined,
+    clearBankMappings: async () => undefined,
+    clearTransactions: async () => undefined,
+  };
+
+  const app = createApp({ db });
+  const payload = {
+    transactions: [
+      {
+        bank_name: "Test Bank",
+        booking_text: "Payment",
+        booking_amount: "10.00",
+        booking_type: "CARD",
+        booking_date: "2024-01-01",
+        booking_date_raw: "2024-01-01",
+        booking_date_iso: null,
+      },
+    ],
+  };
+
+  await request(app)
+    .post("/transactions")
+    .set("Cookie", "umsatz_token=test")
+    .send(payload)
+    .expect(204);
+
+  assert.equal(stored.length, 1);
+  assert.deepEqual(stored[0], payload.transactions[0]);
+});

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,302 @@
+const express = require("express");
+const cookieParser = require("cookie-parser");
+const { randomBytes } = require("node:crypto");
+
+const DEFAULT_TOKEN_TTL = 60 * 60 * 24; // 24 hours
+const ALLOWED_TRANSACTION_KEYS = new Set([
+  "bank_name",
+  "booking_date",
+  "booking_date_raw",
+  "booking_date_iso",
+  "booking_text",
+  "booking_type",
+  "booking_amount",
+]);
+
+function parseOrigins(input) {
+  if (!input) {
+    return [];
+  }
+  return input
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+function isUnifiedTransaction(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  for (const key of Object.keys(value)) {
+    if (!ALLOWED_TRANSACTION_KEYS.has(key)) {
+      return false;
+    }
+  }
+  if (typeof value.booking_text !== "string" || typeof value.booking_amount !== "string") {
+    return false;
+  }
+  if (typeof value.bank_name !== "string" || value.bank_name.length === 0) {
+    return false;
+  }
+  if (typeof value.booking_date !== "string" || value.booking_date.length === 0) {
+    return false;
+  }
+  if (typeof value.booking_type !== "string") {
+    return false;
+  }
+  return true;
+}
+
+function isBankMapping(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const maybe = value;
+  if (typeof maybe.bank_name !== "string" || maybe.bank_name.trim().length === 0) {
+    return false;
+  }
+  if (!Array.isArray(maybe.booking_date) || !Array.isArray(maybe.booking_text) || !Array.isArray(maybe.booking_type) || !Array.isArray(maybe.booking_amount)) {
+    return false;
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(maybe, "booking_date_parse_format") &&
+    typeof maybe.booking_date_parse_format !== "string"
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function asyncHandler(handler) {
+  return (req, res, next) => {
+    Promise.resolve(handler(req, res, next)).catch(next);
+  };
+}
+
+function createApp({ db, origins = [] }) {
+  const app = express();
+  const maxPayload = process.env.MAX_PAYLOAD ?? "2mb";
+  const allowedOrigins = new Set(origins.length > 0 ? origins : parseOrigins(process.env.ALLOWED_ORIGINS));
+  const tokenCookieName = process.env.TOKEN_COOKIE_NAME ?? "umsatz_token";
+  const tokenTtlSeconds = Math.max(60, parseInt(process.env.AUTH_TOKEN_TTL ?? "" + DEFAULT_TOKEN_TTL, 10) || DEFAULT_TOKEN_TTL);
+  const nodeEnv = (process.env.NODE_ENV ?? "development").toLowerCase();
+  const secureCookies = nodeEnv === "production";
+
+  app.use((req, res, next) => {
+    const origin = req.headers.origin;
+    if (origin && (allowedOrigins.size === 0 || allowedOrigins.has(origin))) {
+      res.header("Access-Control-Allow-Origin", origin);
+      res.header("Access-Control-Allow-Credentials", "true");
+      res.header("Vary", "Origin");
+    }
+    res.header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
+    res.header("Access-Control-Allow-Headers", "Content-Type");
+    if (req.method === "OPTIONS") {
+      res.status(204).end();
+      return;
+    }
+    next();
+  });
+
+  app.use(express.json({ limit: maxPayload }));
+  app.use(cookieParser());
+
+  function setAuthCookie(res, token) {
+    res.cookie(tokenCookieName, token, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: secureCookies,
+      maxAge: tokenTtlSeconds * 1000,
+      path: "/",
+    });
+  }
+
+  async function requireAuth(req, res, next) {
+    const token = req.cookies[tokenCookieName];
+    if (!token) {
+      res.status(401).json({ error: "AUTH_REQUIRED" });
+      return;
+    }
+    const exists = await db.tokenExists(token);
+    if (!exists) {
+      res.status(401).json({ error: "INVALID_TOKEN" });
+      return;
+    }
+    req.authToken = token;
+    next();
+  }
+
+  app.post(
+    "/auth/token",
+    asyncHandler(async (req, res) => {
+      const token = randomBytes(32).toString("base64url");
+      const record = await db.createToken(token);
+      setAuthCookie(res, token);
+      res.status(201).json({
+        token,
+        created_on: record?.created_on ?? null,
+        accessed_on: record?.accessed_on ?? null,
+        maxAge: tokenTtlSeconds,
+      });
+    }),
+  );
+
+  app.post(
+    "/auth/session",
+    asyncHandler(async (req, res) => {
+      const supplied = typeof req.body?.token === "string" ? req.body.token.trim() : req.cookies[tokenCookieName];
+      if (!supplied) {
+        res.status(400).json({ error: "TOKEN_REQUIRED" });
+        return;
+      }
+      const record = await db.touchToken(supplied);
+      if (!record) {
+        res.status(401).json({ error: "INVALID_TOKEN" });
+        return;
+      }
+      setAuthCookie(res, supplied);
+      res.json({
+        token: supplied,
+        created_on: record.created_on,
+        accessed_on: record.accessed_on,
+        maxAge: tokenTtlSeconds,
+      });
+    }),
+  );
+
+  app.post(
+    "/auth/logout",
+    asyncHandler(async (req, res) => {
+      res.clearCookie(tokenCookieName, {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: secureCookies,
+        path: "/",
+      });
+      res.status(204).end();
+    }),
+  );
+
+  app.get(
+    "/settings",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      const settings = await db.getSettings(req.authToken);
+      res.json({ settings });
+    }),
+  );
+
+  app.put(
+    "/settings",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (typeof req.body !== "object" || req.body === null) {
+        res.status(400).json({ error: "INVALID_SETTINGS" });
+        return;
+      }
+      const saved = await db.updateSettings(req.authToken, req.body);
+      if (!saved) {
+        res.status(404).json({ error: "TOKEN_NOT_FOUND" });
+        return;
+      }
+      res.json({ settings: saved });
+    }),
+  );
+
+  app.get(
+    "/transactions",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      const transactions = await db.listTransactions(req.authToken);
+      res.json({ transactions });
+    }),
+  );
+
+  app.post(
+    "/transactions",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      const entries = Array.isArray(req.body?.transactions) ? req.body.transactions : [];
+      const sanitized = entries.filter(isUnifiedTransaction);
+      if (sanitized.length !== entries.length) {
+        res.status(400).json({ error: "INVALID_TRANSACTION_PAYLOAD" });
+        return;
+      }
+      await db.replaceTransactions(req.authToken, sanitized);
+      res.status(204).end();
+    }),
+  );
+
+  app.get(
+    "/transactions/masked",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      const transactions = await db.readMaskedTransactions(req.authToken);
+      res.json({ transactions });
+    }),
+  );
+
+  app.post(
+    "/transactions/masked",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      const entries = Array.isArray(req.body?.transactions) ? req.body.transactions : [];
+      const sanitized = entries.filter(isUnifiedTransaction);
+      if (sanitized.length !== entries.length) {
+        res.status(400).json({ error: "INVALID_TRANSACTION_PAYLOAD" });
+        return;
+      }
+      await db.replaceMaskedTransactions(req.authToken, sanitized);
+      res.status(204).end();
+    }),
+  );
+
+  app.get(
+    "/bank-mapping",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      const mappings = await db.listBankMappings(req.authToken);
+      res.json({ mappings });
+    }),
+  );
+
+  app.post(
+    "/bank-mapping",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      if (!isBankMapping(req.body)) {
+        res.status(400).json({ error: "INVALID_MAPPING" });
+        return;
+      }
+      await db.upsertBankMapping(req.authToken, req.body);
+      res.status(204).end();
+    }),
+  );
+
+  app.delete(
+    "/storage",
+    requireAuth,
+    asyncHandler(async (req, res) => {
+      await Promise.all([
+        db.clearTransactions(req.authToken),
+        db.clearBankMappings(req.authToken),
+        db.updateSettings(req.authToken, {}),
+      ]);
+      res.status(204).end();
+    }),
+  );
+
+  app.use((err, req, res, _next) => {
+    console.error("Unhandled error", err);
+    res.status(500).json({ error: "INTERNAL_SERVER_ERROR" });
+  });
+
+  return app;
+}
+
+module.exports = {
+  createApp,
+  parseOrigins,
+  isUnifiedTransaction,
+  isBankMapping,
+};

--- a/backend/db/001_init.sql
+++ b/backend/db/001_init.sql
@@ -1,0 +1,85 @@
+CREATE TABLE IF NOT EXISTS user_tokens (
+  token TEXT PRIMARY KEY,
+  settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_on TIMESTAMPTZ NOT NULL DEFAULT now(),
+  accessed_on TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS transactions (
+  id BIGSERIAL PRIMARY KEY,
+  token TEXT NOT NULL REFERENCES user_tokens(token) ON DELETE CASCADE,
+  amount TEXT,
+  booking_text TEXT,
+  booking_category TEXT,
+  masked_data JSONB DEFAULT '{}'::jsonb,
+  created_on TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_on TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS bank_mapping (
+  id BIGSERIAL PRIMARY KEY,
+  token TEXT NOT NULL REFERENCES user_tokens(token) ON DELETE CASCADE,
+  bank_name TEXT NOT NULL,
+  booking_date TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+  amount TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+  booking_text TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+  booking_type TEXT[] NOT NULL DEFAULT ARRAY[]::text[],
+  booking_date_parse_format TEXT NOT NULL DEFAULT '',
+  created_on TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_on TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT bank_mapping_unique_bank_per_token UNIQUE (token, bank_name)
+);
+
+CREATE OR REPLACE FUNCTION touch_user_token(p_token TEXT)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+AS
+$$
+DECLARE
+  updated_count INTEGER;
+BEGIN
+  UPDATE user_tokens
+     SET accessed_on = now()
+   WHERE token = p_token;
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+  RETURN updated_count > 0;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION user_tokens_settings_access()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS
+$$
+BEGIN
+  NEW.accessed_on = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_user_tokens_settings_access
+  BEFORE UPDATE OF settings
+  ON user_tokens
+  FOR EACH ROW
+  EXECUTE FUNCTION user_tokens_settings_access();
+
+CREATE OR REPLACE FUNCTION set_row_updated_on()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS
+$$
+BEGIN
+  NEW.updated_on = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_transactions_updated_on
+  BEFORE UPDATE ON transactions
+  FOR EACH ROW
+  EXECUTE FUNCTION set_row_updated_on();
+
+CREATE TRIGGER trg_bank_mapping_updated_on
+  BEFORE UPDATE ON bank_mapping
+  FOR EACH ROW
+  EXECUTE FUNCTION set_row_updated_on();

--- a/backend/db/index.js
+++ b/backend/db/index.js
@@ -1,0 +1,241 @@
+const { Pool } = require("pg");
+
+const MASKED_SNAPSHOT_CATEGORY = "__masked_snapshot__";
+
+function createPool(options = {}) {
+  const connectionString = options.connectionString ?? process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is not configured.");
+  }
+  const sslMode = options.ssl ?? process.env.PGSSLMODE;
+  let ssl = undefined;
+  if (typeof sslMode === "string" && sslMode.toLowerCase() === "require") {
+    ssl = { rejectUnauthorized: false };
+  }
+  return new Pool({
+    connectionString,
+    max: options.max ?? 10,
+    ssl,
+  });
+}
+
+async function withClient(pool, callback) {
+  const client = await pool.connect();
+  try {
+    return await callback(client);
+  } finally {
+    client.release();
+  }
+}
+
+function createDb(pool) {
+  async function createToken(token) {
+    const insertResult = await pool.query(
+      `INSERT INTO user_tokens(token)
+       VALUES ($1)
+       ON CONFLICT (token) DO NOTHING
+       RETURNING token, created_on, accessed_on`,
+      [token],
+    );
+
+    if (insertResult.rowCount === 0) {
+      await pool.query("SELECT touch_user_token($1)", [token]);
+      const existing = await pool.query(
+        "SELECT token, created_on, accessed_on FROM user_tokens WHERE token = $1",
+        [token],
+      );
+      return existing.rows[0] ?? null;
+    }
+
+    return insertResult.rows[0];
+  }
+
+  async function touchToken(token) {
+    const result = await pool.query("SELECT touch_user_token($1) AS ok", [token]);
+    if (!result.rows[0]?.ok) {
+      return null;
+    }
+    const details = await pool.query(
+      "SELECT token, created_on, accessed_on FROM user_tokens WHERE token = $1",
+      [token],
+    );
+    return details.rows[0] ?? null;
+  }
+
+  async function tokenExists(token) {
+    const result = await pool.query("SELECT 1 FROM user_tokens WHERE token = $1", [token]);
+    return result.rowCount > 0;
+  }
+
+  async function getSettings(token) {
+    await pool.query("SELECT touch_user_token($1)", [token]);
+    const result = await pool.query("SELECT settings FROM user_tokens WHERE token = $1", [token]);
+    return result.rows[0]?.settings ?? {};
+  }
+
+  async function updateSettings(token, settings) {
+    const result = await pool.query(
+      "UPDATE user_tokens SET settings = $2 WHERE token = $1 RETURNING settings",
+      [token, settings],
+    );
+    if (result.rowCount === 0) {
+      return null;
+    }
+    return result.rows[0].settings;
+  }
+
+  async function listTransactions(token) {
+    const result = await pool.query(
+      `SELECT masked_data
+         FROM transactions
+        WHERE token = $1 AND booking_category <> $2
+        ORDER BY created_on DESC, id DESC`,
+      [token, MASKED_SNAPSHOT_CATEGORY],
+    );
+    return result.rows
+      .map((row) => row.masked_data)
+      .filter((value) => value && typeof value === "object");
+  }
+
+  async function replaceTransactions(token, entries) {
+    await withClient(pool, async (client) => {
+      await client.query("BEGIN");
+      try {
+        await client.query(
+          "DELETE FROM transactions WHERE token = $1 AND booking_category <> $2",
+          [token, MASKED_SNAPSHOT_CATEGORY],
+        );
+        if (entries.length > 0) {
+          const insertText =
+            "INSERT INTO transactions(token, amount, booking_text, booking_category, masked_data) VALUES ($1, $2, $3, $4, $5::jsonb)";
+          for (const entry of entries) {
+            const payload = JSON.stringify(entry);
+            const amount = typeof entry.booking_amount === "string" ? entry.booking_amount : null;
+            const bookingText = typeof entry.booking_text === "string" ? entry.booking_text : null;
+            const bookingCategory = typeof entry.booking_type === "string" ? entry.booking_type : null;
+            await client.query(insertText, [
+              token,
+              amount,
+              bookingText,
+              bookingCategory,
+              payload,
+            ]);
+          }
+        }
+        await client.query("COMMIT");
+      } catch (error) {
+        await client.query("ROLLBACK");
+        throw error;
+      }
+    });
+  }
+
+  async function readMaskedTransactions(token) {
+    const result = await pool.query(
+      `SELECT masked_data
+         FROM transactions
+        WHERE token = $1 AND booking_category = $2
+        ORDER BY created_on DESC
+        LIMIT 1`,
+      [token, MASKED_SNAPSHOT_CATEGORY],
+    );
+    const payload = result.rows[0]?.masked_data;
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+    return [];
+  }
+
+  async function replaceMaskedTransactions(token, entries) {
+    await withClient(pool, async (client) => {
+      await client.query("BEGIN");
+      try {
+        await client.query(
+          "DELETE FROM transactions WHERE token = $1 AND booking_category = $2",
+          [token, MASKED_SNAPSHOT_CATEGORY],
+        );
+        await client.query(
+          "INSERT INTO transactions(token, booking_category, masked_data) VALUES ($1, $2, $3::jsonb)",
+          [token, MASKED_SNAPSHOT_CATEGORY, JSON.stringify(entries)],
+        );
+        await client.query("COMMIT");
+      } catch (error) {
+        await client.query("ROLLBACK");
+        throw error;
+      }
+    });
+  }
+
+  async function listBankMappings(token) {
+    const result = await pool.query(
+      `SELECT bank_name, booking_date, amount, booking_text, booking_type, booking_date_parse_format
+         FROM bank_mapping
+        WHERE token = $1
+        ORDER BY bank_name ASC`,
+      [token],
+    );
+    return result.rows.map((row) => ({
+      bank_name: row.bank_name,
+      booking_date: Array.isArray(row.booking_date) ? row.booking_date : [],
+      booking_amount: Array.isArray(row.amount) ? row.amount : [],
+      booking_text: Array.isArray(row.booking_text) ? row.booking_text : [],
+      booking_type: Array.isArray(row.booking_type) ? row.booking_type : [],
+      booking_date_parse_format: typeof row.booking_date_parse_format === "string" ? row.booking_date_parse_format : "",
+    }));
+  }
+
+  async function upsertBankMapping(token, mapping) {
+    await pool.query(
+      `INSERT INTO bank_mapping(token, bank_name, booking_date, amount, booking_text, booking_type, booking_date_parse_format)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (token, bank_name)
+       DO UPDATE SET
+         booking_date = EXCLUDED.booking_date,
+         amount = EXCLUDED.amount,
+         booking_text = EXCLUDED.booking_text,
+         booking_type = EXCLUDED.booking_type,
+         booking_date_parse_format = EXCLUDED.booking_date_parse_format,
+         updated_on = now()`,
+      [
+        token,
+        mapping.bank_name,
+        mapping.booking_date,
+        mapping.booking_amount,
+        mapping.booking_text,
+        mapping.booking_type,
+        mapping.booking_date_parse_format,
+      ],
+    );
+  }
+
+  async function clearBankMappings(token) {
+    await pool.query("DELETE FROM bank_mapping WHERE token = $1", [token]);
+  }
+
+  async function clearTransactions(token) {
+    await pool.query("DELETE FROM transactions WHERE token = $1", [token]);
+  }
+
+  return {
+    createToken,
+    touchToken,
+    tokenExists,
+    getSettings,
+    updateSettings,
+    listTransactions,
+    replaceTransactions,
+    readMaskedTransactions,
+    replaceMaskedTransactions,
+    listBankMappings,
+    upsertBankMapping,
+    clearBankMappings,
+    clearTransactions,
+    MASKED_SNAPSHOT_CATEGORY,
+  };
+}
+
+module.exports = {
+  createPool,
+  createDb,
+  MASKED_SNAPSHOT_CATEGORY,
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,31 @@
+const http = require("node:http");
+const { createPool, createDb } = require("./db");
+const { createApp } = require("./app");
+
+async function start() {
+  const port = parseInt(process.env.PORT ?? "8080", 10);
+  const pool = createPool();
+  const db = createDb(pool);
+  const app = createApp({ db });
+
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(port, resolve));
+  console.log(`Backend server listening on port ${port}`);
+
+  const shutdown = () => {
+    console.log("Shutting down backend server");
+    server.close(() => {
+      pool.end().catch((error) => {
+        console.error("Failed to close database pool", error);
+      });
+    });
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+start().catch((error) => {
+  console.error("Failed to start backend server", error);
+  process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -4,10 +4,20 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "test": "npm run build",
-    "start:auth": "node server/index.js"
+    "test": "npm run build && node --test",
+    "start:auth": "node server/index.js",
+    "start:backend": "node backend/server.js"
+  },
+  "dependencies": {
+    "cookie-parser": "^1.4.6",
+    "express": "^4.19.2",
+    "pg": "^8.11.5"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.6",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.30",
+    "supertest": "^6.3.4",
     "typescript": "^5.4.0"
   }
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -216,3 +216,29 @@ export async function requestNewToken(): Promise<TokenValidationResult> {
     message: result.message,
   };
 }
+
+function resolveLogoutEndpoint(): string {
+  const tokenEndpoint = resolveTokenEndpoint();
+  try {
+    const url = new URL(tokenEndpoint, window.location.href);
+    if (url.pathname.endsWith("/token")) {
+      url.pathname = url.pathname.replace(/\/token$/, "/logout");
+      url.search = "";
+      url.hash = "";
+      return url.toString();
+    }
+    return new URL("/auth/logout", url).toString();
+  } catch {
+    return "/auth/logout";
+  }
+}
+
+export async function logout(): Promise<void> {
+  const endpoint = resolveLogoutEndpoint();
+  try {
+    await fetch(endpoint, { method: "POST", credentials: "include" });
+  } catch (error) {
+    console.warn("Logout request failed", error);
+  }
+  deleteTokenCookie();
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,12 +1,112 @@
 import { sanitizeDisplaySettings } from "./displaySettings.js";
 import { AnonRule, BankMapping, DisplaySettings, UnifiedTx } from "./types.js";
 
+declare global {
+  interface Window {
+    BACKEND_BASE_URL?: string;
+  }
+}
+
+function resolveApiBase(): string {
+  const meta = document.querySelector('meta[name="backend-base-url"]');
+  const metaContent = meta?.getAttribute("content")?.trim();
+  if (metaContent) {
+    return metaContent.replace(/\/$/, "");
+  }
+  if (typeof window !== "undefined" && typeof window.BACKEND_BASE_URL === "string") {
+    return window.BACKEND_BASE_URL.replace(/\/$/, "");
+  }
+  return "";
+}
+
+const API_BASE_URL = resolveApiBase();
+
+function fireAndForget(promise: Promise<unknown>, context: string): void {
+  void promise.catch((error) => {
+    console.error(`${context} failed`, error);
+  });
+}
+
+async function apiRequest(path: string, init?: RequestInit): Promise<Response> {
+  const url = `${API_BASE_URL}${path}`;
+  const headers = new Headers(init?.headers);
+  if (!headers.has("Accept")) {
+    headers.set("Accept", "application/json");
+  }
+  const hasBody = init?.body != null;
+  if (hasBody && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  const response = await fetch(url, {
+    ...init,
+    headers,
+    credentials: "include",
+  });
+  if (!response.ok) {
+    const message = await response.text().catch(() => "");
+    throw new Error(
+      message && message.trim().length > 0
+        ? `Request to ${path} failed with status ${response.status}: ${message}`
+        : `Request to ${path} failed with status ${response.status}`,
+    );
+  }
+  return response;
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  const text = await response.text();
+  if (!text) {
+    return {} as T;
+  }
+  return JSON.parse(text) as T;
+}
+
 const BANK_MAPPINGS_KEY = "bank_mappings_v1";
 const TRANSACTIONS_KEY = "transactions_unified_v1";
 const TRANSACTIONS_MASKED_KEY = "transactions_unified_masked_v1";
 const ANON_RULES_KEY = "anonymization_rules_v1";
 const DISPLAY_SETTINGS_KEY = "display_settings_v1";
 const CURRENT_RULE_VERSION = 2;
+
+const bankMappingsCache: BankMapping[] = [];
+let transactionsCache: UnifiedTx[] = [];
+let maskedTransactionsCache: UnifiedTx[] = [];
+let displaySettingsCache: DisplaySettings = sanitizeDisplaySettings(null);
+let settingsCache: Record<string, unknown> = {};
+let initialized = false;
+let initializationPromise: Promise<void> | null = null;
+
+export async function initializeStorage(): Promise<void> {
+  if (initialized) {
+    return;
+  }
+  if (!initializationPromise) {
+    initializationPromise = (async () => {
+      const [settings, mappings, transactions, masked] = await Promise.all([
+        fetchSettingsFromBackend(),
+        fetchBankMappingsFromBackend(),
+        fetchTransactionsFromBackend(),
+        fetchMaskedTransactionsFromBackend(),
+      ]);
+      settingsCache = settings;
+      const display = settings[DISPLAY_SETTINGS_KEY];
+      if (display && typeof display === "object") {
+        displaySettingsCache = sanitizeDisplaySettings(display as Partial<DisplaySettings>);
+      } else {
+        displaySettingsCache = sanitizeDisplaySettings(null);
+      }
+      bankMappingsCache.length = 0;
+      bankMappingsCache.push(...mappings);
+      transactionsCache = transactions;
+      maskedTransactionsCache = masked;
+      initialized = true;
+    })().catch((error) => {
+      initializationPromise = null;
+      throw error;
+    });
+  }
+  await initializationPromise;
+}
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string");
@@ -72,15 +172,24 @@ function safeParse<T>(text: string | null): T | null {
   }
 }
 
-export function loadBankMappings(): BankMapping[] {
-  const parsed = safeParse<unknown>(localStorage.getItem(BANK_MAPPINGS_KEY));
-  if (!Array.isArray(parsed)) {
-    return [];
-  }
-  return parsed
+async function fetchBankMappingsFromBackend(): Promise<BankMapping[]> {
+  const response = await apiRequest("/bank-mapping");
+  const payload = await readJson<{ mappings?: unknown }>(response);
+  const entries = Array.isArray(payload.mappings) ? payload.mappings : [];
+  return entries
     .map(toBankMapping)
     .filter((entry): entry is BankMapping => entry !== null)
     .map(sanitizeBankMapping);
+}
+
+async function fetchSettingsFromBackend(): Promise<Record<string, unknown>> {
+  const response = await apiRequest("/settings");
+  const payload = await readJson<{ settings?: Record<string, unknown> }>(response);
+  return payload.settings ?? {};
+}
+
+export function loadBankMappings(): BankMapping[] {
+  return bankMappingsCache.map(sanitizeBankMapping);
 }
 
 export function importBankMappings(raw: unknown): BankMapping[] | null {
@@ -91,7 +200,19 @@ export function importBankMappings(raw: unknown): BankMapping[] | null {
     .map(toBankMapping)
     .filter((entry): entry is BankMapping => entry !== null)
     .map(sanitizeBankMapping);
-  localStorage.setItem(BANK_MAPPINGS_KEY, JSON.stringify(sanitized, null, 2));
+  bankMappingsCache.length = 0;
+  bankMappingsCache.push(...sanitized);
+  fireAndForget(
+    Promise.all(
+      sanitized.map((entry) =>
+        apiRequest("/bank-mapping", {
+          method: "POST",
+          body: JSON.stringify(entry),
+        }),
+      ),
+    ),
+    "importBankMappings",
+  );
   return sanitized;
 }
 
@@ -100,24 +221,34 @@ export function saveBankMapping(mapping: BankMapping): void {
   const existing = loadBankMappings();
   const index = existing.findIndex((entry) => entry.bank_name === sanitized.bank_name);
   if (index >= 0) {
-    existing[index] = sanitized;
+    bankMappingsCache[index] = sanitized;
   } else {
-    existing.push(sanitized);
+    bankMappingsCache.push(sanitized);
   }
-  localStorage.setItem(BANK_MAPPINGS_KEY, JSON.stringify(existing, null, 2));
+  fireAndForget(
+    apiRequest("/bank-mapping", {
+      method: "POST",
+      body: JSON.stringify(sanitized),
+    }),
+    "saveBankMapping",
+  );
 }
 
 export function loadDisplaySettings(): DisplaySettings {
-  const parsed = safeParse<unknown>(localStorage.getItem(DISPLAY_SETTINGS_KEY));
-  if (parsed && typeof parsed === "object") {
-    return sanitizeDisplaySettings(parsed as Partial<DisplaySettings>);
-  }
-  return sanitizeDisplaySettings(null);
+  return sanitizeDisplaySettings(displaySettingsCache);
 }
 
 export function saveDisplaySettings(settings: DisplaySettings): void {
   const sanitized = sanitizeDisplaySettings(settings);
-  localStorage.setItem(DISPLAY_SETTINGS_KEY, JSON.stringify(sanitized, null, 2));
+  displaySettingsCache = sanitized;
+  settingsCache = { ...settingsCache, [DISPLAY_SETTINGS_KEY]: sanitized };
+  fireAndForget(
+    apiRequest("/settings", {
+      method: "PUT",
+      body: JSON.stringify(settingsCache),
+    }),
+    "saveDisplaySettings",
+  );
 }
 
 function toUnifiedTx(value: unknown): UnifiedTx | null {
@@ -207,49 +338,81 @@ function sortTransactions(entries: UnifiedTx[]): UnifiedTx[] {
   return [...entries].sort((a, b) => transactionTimestamp(b) - transactionTimestamp(a));
 }
 
-function persistTransactions(key: string, entries: UnifiedTx[]): void {
+async function fetchTransactionsFromBackend(): Promise<UnifiedTx[]> {
+  const response = await apiRequest("/transactions");
+  const payload = await readJson<{ transactions?: unknown }>(response);
+  const parsed = Array.isArray(payload.transactions) ? payload.transactions : [];
+  const normalized = parsed
+    .map(toUnifiedTx)
+    .filter((entry): entry is UnifiedTx => entry !== null)
+    .map(sanitizeTransaction);
+  return sortTransactions(normalized);
+}
+
+async function fetchMaskedTransactionsFromBackend(): Promise<UnifiedTx[]> {
+  const response = await apiRequest("/transactions/masked");
+  const payload = await readJson<{ transactions?: unknown }>(response);
+  const parsed = Array.isArray(payload.transactions) ? payload.transactions : [];
+  const normalized = parsed
+    .map(toUnifiedTx)
+    .filter((entry): entry is UnifiedTx => entry !== null)
+    .map(sanitizeTransaction);
+  return sortTransactions(normalized);
+}
+
+function updateTransactionsCache(entries: UnifiedTx[]): UnifiedTx[] {
   const sanitized = entries.map(sanitizeTransaction);
-  const sorted = sortTransactions(sanitized);
-  localStorage.setItem(key, JSON.stringify(sorted, null, 2));
+  transactionsCache = sortTransactions(sanitized);
+  return [...transactionsCache];
+}
+
+function updateMaskedTransactionsCache(entries: UnifiedTx[]): UnifiedTx[] {
+  const sanitized = entries.map(sanitizeTransaction);
+  maskedTransactionsCache = sortTransactions(sanitized);
+  return [...maskedTransactionsCache];
 }
 
 export function loadTransactions(): UnifiedTx[] {
-  const parsed = safeParse<unknown>(localStorage.getItem(TRANSACTIONS_KEY));
-  if (!Array.isArray(parsed)) {
-    return [];
-  }
-  const normalized = parsed
-    .map(toUnifiedTx)
-    .filter((entry): entry is UnifiedTx => entry !== null)
-    .map(sanitizeTransaction);
-  return sortTransactions(normalized);
+  return [...transactionsCache];
 }
 
 export function saveTransactions(entries: UnifiedTx[]): void {
-  persistTransactions(TRANSACTIONS_KEY, entries);
+  const updated = updateTransactionsCache(entries);
+  fireAndForget(
+    apiRequest("/transactions", {
+      method: "POST",
+      body: JSON.stringify({ transactions: updated }),
+    }),
+    "saveTransactions",
+  );
 }
 
 export function appendTransactions(entries: UnifiedTx[]): UnifiedTx[] {
-  const current = loadTransactions();
-  const combined = current.concat(entries.map(sanitizeTransaction));
-  persistTransactions(TRANSACTIONS_KEY, combined);
-  return sortTransactions(combined);
+  const combined = transactionsCache.concat(entries.map(sanitizeTransaction));
+  const updated = updateTransactionsCache(combined);
+  fireAndForget(
+    apiRequest("/transactions", {
+      method: "POST",
+      body: JSON.stringify({ transactions: updated }),
+    }),
+    "appendTransactions",
+  );
+  return updated;
 }
 
 export function loadMaskedTransactions(): UnifiedTx[] {
-  const parsed = safeParse<unknown>(localStorage.getItem(TRANSACTIONS_MASKED_KEY));
-  if (!Array.isArray(parsed)) {
-    return [];
-  }
-  const normalized = parsed
-    .map(toUnifiedTx)
-    .filter((entry): entry is UnifiedTx => entry !== null)
-    .map(sanitizeTransaction);
-  return sortTransactions(normalized);
+  return [...maskedTransactionsCache];
 }
 
 export function saveMaskedTransactions(entries: UnifiedTx[]): void {
-  persistTransactions(TRANSACTIONS_MASKED_KEY, entries);
+  const updated = updateMaskedTransactionsCache(entries);
+  fireAndForget(
+    apiRequest("/transactions/masked", {
+      method: "POST",
+      body: JSON.stringify({ transactions: updated }),
+    }),
+    "saveMaskedTransactions",
+  );
 }
 
 function isAnonRule(value: unknown): value is AnonRule {
@@ -378,6 +541,19 @@ export function importAnonymizationRules(
 }
 
 export function clearPersistentData(): void {
+  transactionsCache = [];
+  maskedTransactionsCache = [];
+  bankMappingsCache.length = 0;
+  displaySettingsCache = sanitizeDisplaySettings(null);
+  settingsCache = {};
+  initialized = false;
+  initializationPromise = null;
+  fireAndForget(
+    apiRequest("/storage", {
+      method: "DELETE",
+    }),
+    "clearPersistentData",
+  );
   const keys = [
     BANK_MAPPINGS_KEY,
     TRANSACTIONS_KEY,


### PR DESCRIPTION
## Summary
- add an Express backend with token generation/validation and REST routes for settings, transactions, masked transactions, and bank mappings
- create PostgreSQL migrations, triggers, and helper functions to persist tokens and anonymized data
- integrate the frontend storage layer with the backend via initializeStorage caching and document Render.com deployment; add backend tests for key flows

## Testing
- npm run build
- npm run test *(fails: cannot find module 'supertest' because npm install is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6191c60188333977cc383f0db379b