### PR TITLE
Guard session validation endpoint resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ npm run start:backend # Startet das Backend auf PORT (Default 8080)
      - `TOKEN_COOKIE_NAME` – optional (Default `umsatz_token`)
      - `AUTH_TOKEN_TTL` – optional Gültigkeitsdauer der Tokens in Sekunden (Default 86400)
      - `ALLOWED_ORIGINS` – Komma-separierte Liste der Frontend-URLs, die Cookies senden dürfen
+     - `BACKEND_PUBLIC_ORIGIN` – optional, falls die öffentliche Backend-URL nicht automatisch erkannt wird (Render setzt `RENDER_EXTERNAL_URL` bereits passend)
+     - `AUTH_COOKIE_SECURE` / `AUTH_COOKIE_SAMESITE` – optionale Overrides für Spezialfälle (z. B. Staging ohne HTTPS)
+
+   > **Hinweis:** Sobald eine fremde Origin hinterlegt ist, setzt das Backend Cookies automatisch mit `Secure` + `SameSite=None`. Render liefert über `RENDER_EXTERNAL_URL` die eigene Service-URL, wodurch die Erkennung ohne weitere Konfiguration funktioniert.
 
 3. **Migrationen einspielen**
    - Über Render „Shell“ oder lokal mit `psql` verbinden:
@@ -82,8 +86,11 @@ Zum Ausführen: `npm run test` (nach erfolgreichem `npm install`).
 | `TOKEN_COOKIE_NAME`  | Name des Auth-Cookies (Default `umsatz_token`)           |
 | `AUTH_TOKEN_TTL`     | Token-Gültigkeit in Sekunden (min. 60, Default 86400)    |
 | `ALLOWED_ORIGINS`    | Komma-separierte Liste erlaubter Origins für CORS        |
+| `BACKEND_PUBLIC_ORIGIN` | Optional: Öffentliche Origin des Backends (falls automatische Erkennung über `RENDER_EXTERNAL_URL`/Host-Header nicht möglich) |
 | `API_BASE_PATH`      | Optionaler Prefix (z. B. `/api`); Routen bleiben zusätzlich ohne Prefix erreichbar |
 | `MAX_PAYLOAD`        | Optionales Limit für JSON-Bodies (z. B. `2mb`)           |
+| `AUTH_COOKIE_SECURE` | Optionaler Override (`true`/`false`) für das `Secure`-Flag des Auth-Cookies |
+| `AUTH_COOKIE_SAMESITE` | Optionaler Override (`lax`/`strict`/`none`) für `SameSite` des Auth-Cookies |
 
 ## Hinweis zu Storage-Initialisierung
 

--- a/dist/auth.js
+++ b/dist/auth.js
@@ -3,6 +3,21 @@ const DEFAULT_TOKEN_ENDPOINT = "/auth/token";
 const DEFAULT_SESSION_ENDPOINT = "/auth/session";
 let cachedTokenEndpoint = null;
 let cachedSessionEndpoint = null;
+function normalizeEndpointForComparison(endpoint) {
+    if (!endpoint) {
+        return "";
+    }
+    try {
+        const base = typeof window !== "undefined" ? window.location.href : "http://localhost";
+        const url = new URL(endpoint, base);
+        url.search = "";
+        url.hash = "";
+        return url.toString().replace(/\/$/, "");
+    }
+    catch {
+        return endpoint.trim().replace(/\/$/, "");
+    }
+}
 function resolveTokenEndpoint() {
     if (cachedTokenEndpoint) {
         return cachedTokenEndpoint;
@@ -68,14 +83,19 @@ function resolveSessionEndpoint() {
     if (meta) {
         candidates.push(meta.getAttribute("content"));
     }
+    const tokenEndpoint = resolveTokenEndpoint();
+    const normalizedTokenEndpoint = normalizeEndpointForComparison(tokenEndpoint);
     for (const candidate of candidates) {
         const trimmed = candidate?.trim();
-        if (trimmed) {
+        if (!trimmed) {
+            continue;
+        }
+        const normalizedCandidate = normalizeEndpointForComparison(trimmed);
+        if (normalizedCandidate && normalizedCandidate !== normalizedTokenEndpoint) {
             cachedSessionEndpoint = trimmed;
-            return trimmed;
+            return cachedSessionEndpoint;
         }
     }
-    const tokenEndpoint = resolveTokenEndpoint();
     if (tokenEndpoint === DEFAULT_TOKEN_ENDPOINT) {
         cachedSessionEndpoint = DEFAULT_SESSION_ENDPOINT;
         return cachedSessionEndpoint;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -14,6 +14,22 @@ const DEFAULT_SESSION_ENDPOINT = "/auth/session";
 let cachedTokenEndpoint: string | null = null;
 let cachedSessionEndpoint: string | null = null;
 
+function normalizeEndpointForComparison(endpoint: string): string {
+  if (!endpoint) {
+    return "";
+  }
+
+  try {
+    const base = typeof window !== "undefined" ? window.location.href : "http://localhost";
+    const url = new URL(endpoint, base);
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return endpoint.trim().replace(/\/$/, "");
+  }
+}
+
 function resolveTokenEndpoint(): string {
   if (cachedTokenEndpoint) {
     return cachedTokenEndpoint;
@@ -91,15 +107,22 @@ function resolveSessionEndpoint(): string {
     candidates.push(meta.getAttribute("content"));
   }
 
+  const tokenEndpoint = resolveTokenEndpoint();
+  const normalizedTokenEndpoint = normalizeEndpointForComparison(tokenEndpoint);
+
   for (const candidate of candidates) {
     const trimmed = candidate?.trim();
-    if (trimmed) {
+    if (!trimmed) {
+      continue;
+    }
+
+    const normalizedCandidate = normalizeEndpointForComparison(trimmed);
+    if (normalizedCandidate && normalizedCandidate !== normalizedTokenEndpoint) {
       cachedSessionEndpoint = trimmed;
-      return trimmed;
+      return cachedSessionEndpoint;
     }
   }
 
-  const tokenEndpoint = resolveTokenEndpoint();
   if (tokenEndpoint === DEFAULT_TOKEN_ENDPOINT) {
     cachedSessionEndpoint = DEFAULT_SESSION_ENDPOINT;
     return cachedSessionEndpoint;


### PR DESCRIPTION
## Summary
- prevent session endpoint resolution from falling back to the token-generation URL when configured values overlap
- add the same normalization logic to the compiled frontend bundle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6617374e88333bc4bf3558ab3d7f8