### PR TITLE
Add design tokens and helper styles

### DIFF
--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -4,20 +4,141 @@
 
 :root {
   color-scheme: light;
+  --color-brand: #2c67aa;
+  --color-brand-strong: #1f4f85;
+  --color-brand-soft: #e2ebf5;
+  --color-accent: #a4c849;
+  --color-accent-strong: #7d9a34;
+  --color-text-primary: #152036;
+  --color-text-secondary: #475569;
+  --color-background: #f5f7fa;
+  --color-surface: #ffffff;
+  --color-border: #cbd5e1;
+  --color-muted: #e2e8f0;
+  --color-on-brand: #ffffff;
+  --color-focus-ring: rgba(44, 103, 170, 0.45);
 }
 
 body {
-  @apply bg-slate-50 text-slate-900 antialiased;
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  accent-color: var(--color-accent);
+  @apply antialiased;
+}
+
+.app-header {
+  background-color: var(--color-brand);
+  color: var(--color-on-brand);
+  border-bottom: 4px solid var(--color-accent);
+  box-shadow: 0 10px 15px -3px rgba(15, 23, 42, 0.2), 0 4px 6px -4px rgba(15, 23, 42, 0.2);
+}
+
+.app-header a {
+  color: var(--color-on-brand);
+}
+
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-brand);
+  background-color: var(--color-brand);
+  color: var(--color-on-brand);
+  font-weight: 600;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-primary:hover,
+.btn-primary:focus-visible {
+  background-color: var(--color-brand-strong);
+  border-color: var(--color-brand-strong);
+}
+
+.btn-primary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px var(--color-focus-ring);
+}
+
+.btn-primary:active {
+  background-color: var(--color-brand-strong);
+  border-color: var(--color-brand-strong);
+  transform: translateY(1px);
+}
+
+.link {
+  color: var(--color-brand);
+  font-weight: 500;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+.link:hover,
+.link:focus-visible {
+  color: var(--color-brand-strong);
+  text-decoration-color: var(--color-brand-strong);
+}
+
+.link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px var(--color-focus-ring);
+}
+
+.login-section {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 1rem;
+  box-shadow: 0 20px 25px -5px rgba(15, 23, 42, 0.1), 0 10px 10px -5px rgba(15, 23, 42, 0.04);
+  padding: 2rem;
+  color: var(--color-text-primary);
+}
+
+.focus-brand:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px var(--color-focus-ring);
 }
 
 input,
 select,
 textarea {
-  @apply rounded-lg border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  color: var(--color-text-primary);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-button:disabled {
-  @apply cursor-not-allowed opacity-60;
+input::placeholder,
+select::placeholder,
+textarea::placeholder {
+  color: var(--color-text-secondary);
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  border-color: var(--color-brand);
+  box-shadow: 0 0 0 4px var(--color-focus-ring);
+  outline: none;
+}
+
+button:disabled,
+.btn-primary:disabled {
+  background-color: var(--color-muted);
+  border-color: var(--color-muted);
+  color: var(--color-text-secondary);
+  cursor: not-allowed;
+  opacity: 0.7;
 }
 
 .table-compact th,


### PR DESCRIPTION
## Summary
- define CSS custom properties for brand, accent, text, and background colors
- refresh base element styling to use the new tokens and improve contrast
- add helper classes for headers, buttons, links, login sections, and focus rings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690c66a4ecc88333a90fbd3bf8dfaf6c