### PR TITLE
feat: refresh token login styling

### DIFF
--- a/frontend/src/components/TokenLogin.vue
+++ b/frontend/src/components/TokenLogin.vue
@@ -1,54 +1,59 @@
 <template>
-  <div class="flex min-h-screen items-center justify-center bg-slate-900 px-4 py-16">
-    <div class="w-full max-w-md rounded-2xl bg-white p-10 shadow-xl">
-      <h1 class="text-2xl font-semibold text-slate-900">Umsatz Anonymizer</h1>
-      <p class="mt-2 text-sm text-slate-600">
+  <div class="login-page">
+    <div class="login-card">
+      <a href="/" class="login-logo focus-brand" aria-label="Zur Startseite">
+        <img src="/logo.svg" alt="Umsatz Anonymizer" />
+      </a>
+      <h1 class="text-2xl font-semibold">Umsatz Anonymizer</h1>
+      <p class="mt-2 text-sm text-muted">
         Bitte geben Sie Ihr Zugriffstoken ein, um das Tool zu verwenden.
       </p>
       <form class="mt-8 space-y-8" @submit.prevent="onSubmit">
         <div class="space-y-6">
-          <div class="rounded-xl border border-slate-200 bg-white/60 p-5 shadow-sm">
-            <h2 class="text-sm font-semibold text-slate-700">Token manuell eingeben</h2>
-            <label for="token" class="mt-3 block text-sm font-medium text-slate-700">Token</label>
-            <input
-              id="token"
-              v-model="token"
-              type="password"
-              required
-              autocomplete="off"
-              class="mt-2 w-full rounded-lg border border-slate-300 px-3 py-2 text-base shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-            />
+          <div class="login-section space-y-3">
+            <h2 class="text-sm font-semibold">Token manuell eingeben</h2>
+            <div class="form-field">
+              <label for="token" class="block text-sm font-medium">Token</label>
+              <input
+                id="token"
+                v-model="token"
+                type="password"
+                required
+                autocomplete="off"
+                class="w-full focus-brand"
+              />
+            </div>
           </div>
-          <div class="flex items-center gap-3 text-slate-400">
-            <span class="h-px flex-1 bg-slate-200"></span>
+          <div class="flex items-center gap-3 text-muted">
+            <span class="divider-line"></span>
             <span class="text-xs font-semibold uppercase tracking-wide">oder</span>
-            <span class="h-px flex-1 bg-slate-200"></span>
+            <span class="divider-line"></span>
           </div>
-          <div class="rounded-xl border border-dashed border-slate-300 bg-slate-50/80 p-5">
-            <h2 class="text-sm font-semibold text-slate-700">Token aus Datei laden</h2>
-            <p class="mt-1 text-sm text-slate-500">
+          <div class="login-section upload-area">
+            <h2 class="text-sm font-semibold">Token aus Datei laden</h2>
+            <p class="mt-1 text-sm text-muted">
               Laden Sie eine Textdatei mit Ihrem Token hoch. Der Inhalt wird automatisch in das Feld übernommen.
             </p>
             <input
               type="file"
               accept=".txt,.token,text/plain"
-              class="mt-4 block w-full cursor-pointer rounded-lg border border-dashed border-slate-300 bg-white px-3 py-2 text-sm text-slate-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              class="mt-4 block w-full cursor-pointer focus-brand"
               @change="loadTokenFromFile"
             />
             <p v-if="fileError" class="mt-2 text-sm font-medium text-rose-600">{{ fileError }}</p>
           </div>
         </div>
-        <div class="flex items-center justify-between">
+        <div class="flex flex-wrap items-center gap-3 sm:justify-between">
           <button
             type="submit"
-            class="inline-flex items-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            class="btn-primary focus-brand"
           >
             <span v-if="auth.loading" class="mr-2 inline-flex h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"></span>
             Anmelden
           </button>
           <button
             type="button"
-            class="text-sm font-medium text-indigo-600 hover:text-indigo-500"
+            class="btn-accent focus-brand"
             @click="onRequestToken"
           >
             Neues Token anfordern
@@ -56,7 +61,7 @@
         </div>
         <p v-if="errorMessage" class="text-sm font-medium text-rose-600">{{ errorMessage }}</p>
         <p v-if="downloadError" class="text-sm font-medium text-rose-600">{{ downloadError }}</p>
-        <p v-if="auth.lastValidation?.message" class="text-sm text-slate-500">
+        <p v-if="auth.lastValidation?.message" class="text-sm text-muted">
           {{ auth.lastValidation.message }}
         </p>
       </form>
@@ -64,7 +69,7 @@
 
     <div
       v-if="showTokenModal"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 px-4"
+      class="modal-backdrop"
       role="dialog"
       aria-modal="true"
       :aria-labelledby="modalTitleId"
@@ -72,16 +77,16 @@
     >
       <div
         ref="modalRef"
-        class="w-full max-w-lg rounded-2xl bg-white p-8 shadow-2xl focus:outline-none"
+        class="modal-card focus-brand"
         tabindex="-1"
         @keydown="onModalKeydown"
       >
         <div class="flex items-start justify-between">
           <div>
-            <h2 :id="modalTitleId" class="text-xl font-semibold text-slate-900">
+            <h2 :id="modalTitleId" class="text-xl font-semibold">
               {{ modalContext === "login" ? "Willkommen zurück!" : "Neues Token erstellt" }}
             </h2>
-            <p :id="modalDescriptionId" class="mt-2 text-sm text-slate-600">
+            <p :id="modalDescriptionId" class="mt-2 text-sm text-muted">
               {{
                 modalContext === "login"
                   ? auth.lastValidation?.message ?? "Sie haben sich erfolgreich angemeldet."
@@ -91,10 +96,10 @@
             </p>
           </div>
         </div>
-        <div v-if="modalContext === 'login'" class="mt-6 space-y-4 text-sm text-slate-600">
+        <div v-if="modalContext === 'login'" class="mt-6 space-y-4 text-sm text-muted">
           <p>Schön, dass Sie wieder da sind! Sie können die Anwendung jetzt wie gewohnt verwenden.</p>
         </div>
-        <div v-else class="mt-6 space-y-4 text-sm text-slate-600">
+        <div v-else class="mt-6 space-y-4 text-sm text-muted">
           <p>
             Laden Sie Ihr neues Zugriffstoken als Datei herunter und bewahren Sie es an einem sicheren Ort auf. Das Token
             wird benötigt, um sich künftig anzumelden.
@@ -106,7 +111,7 @@
           <div class="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
             <button
               type="button"
-              class="inline-flex items-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-slate-300"
+              class="btn-accent focus-brand"
               :disabled="!requestedToken"
               @click="downloadRequestedToken"
             >
@@ -119,7 +124,7 @@
           <button
             ref="closeButtonRef"
             type="button"
-            class="inline-flex items-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            class="btn-primary focus-brand"
             @click="closeModal"
           >
             Schließen

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -28,6 +28,45 @@ body {
   @apply antialiased;
 }
 
+.login-page {
+  display: flex;
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 1rem;
+  background: radial-gradient(circle at top, rgba(44, 103, 170, 0.12), transparent 60%),
+    radial-gradient(circle at bottom, rgba(164, 200, 73, 0.1), transparent 55%), var(--color-background);
+}
+
+.login-card {
+  width: 100%;
+  max-width: 28rem;
+  padding: 2.5rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface);
+  box-shadow: 0 25px 50px -12px rgba(21, 32, 54, 0.25);
+}
+
+.login-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  padding: 0.75rem;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+}
+
+.login-logo img {
+  height: 2.5rem;
+  width: auto;
+}
+
+.text-muted {
+  color: var(--color-text-secondary);
+}
+
 .app-header {
   background-color: var(--color-brand);
   color: var(--color-on-brand);
@@ -70,6 +109,37 @@ body {
   transform: translateY(1px);
 }
 
+.btn-accent {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-accent);
+  background-color: var(--color-accent);
+  color: var(--color-on-brand);
+  font-weight: 600;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+}
+
+.btn-accent:hover,
+.btn-accent:focus-visible {
+  background-color: var(--color-accent-strong);
+  border-color: var(--color-accent-strong);
+}
+
+.btn-accent:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px var(--color-focus-ring);
+}
+
+.btn-accent:disabled {
+  background-color: var(--color-muted);
+  border-color: var(--color-muted);
+  color: var(--color-text-secondary);
+}
+
 .link {
   color: var(--color-brand);
   font-weight: 500;
@@ -97,6 +167,17 @@ body {
   box-shadow: 0 20px 25px -5px rgba(15, 23, 42, 0.1), 0 10px 10px -5px rgba(15, 23, 42, 0.04);
   padding: 2rem;
   color: var(--color-text-primary);
+}
+
+.upload-area {
+  border-style: dashed;
+  background-color: var(--color-brand-soft);
+}
+
+.divider-line {
+  flex: 1 1 0%;
+  height: 1px;
+  background-color: var(--color-muted);
 }
 
 .focus-brand:focus-visible {
@@ -139,6 +220,27 @@ button:disabled,
   color: var(--color-text-secondary);
   cursor: not-allowed;
   opacity: 0.7;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  background: rgba(21, 32, 54, 0.82);
+}
+
+.modal-card {
+  width: 100%;
+  max-width: 36rem;
+  padding: 2.5rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface);
+  box-shadow: 0 30px 60px -20px rgba(21, 32, 54, 0.45);
 }
 
 .table-compact th,


### PR DESCRIPTION
## Summary
- add a branded logo link and adopt the new login utility classes in the token login view
- refresh button, input, and modal styling to keep focus indicators and improve contrast with the updated palette
- introduce reusable CSS helpers for the login layout, accent buttons, and modal backdrop/card visuals

## Testing
- npm run build --workspace frontend *(fails: Vite build requires %VITE_BASE_URL% in index.html)*

------
https://chatgpt.com/codex/tasks/task_e_690c6920f6a08333b32a024f286f10ae