### PR TITLE
feat: refresh main layout styling

### DIFF
--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,16 +1,18 @@
 <template>
   <div class="flex min-h-screen">
-    <aside class="hidden w-72 flex-col bg-slate-900 text-slate-100 lg:flex">
-      <div class="flex items-center justify-between px-6 py-6">
-        <h2 class="text-lg font-semibold">Umsatz Anonymizer</h2>
+    <aside class="app-sidebar hidden lg:flex" aria-label="Hauptnavigation">
+      <div class="app-sidebar__header">
+        <RouterLink to="/" aria-label="Startseite" class="app-logo">
+          <img src="/logo.svg" alt="" />
+        </RouterLink>
       </div>
-      <nav class="flex-1 space-y-1 px-4 py-4">
+      <nav class="app-sidebar__nav">
         <RouterLink
           v-for="item in navigation"
           :key="item.to"
           :to="item.to"
-          class="group flex items-center rounded-lg px-3 py-2 text-sm font-medium transition hover:bg-slate-800"
-          :class="{ 'bg-indigo-600 text-white hover:bg-indigo-500': route.path.startsWith(item.to) }"
+          class="app-nav-link"
+          :class="{ 'is-active': route.path.startsWith(item.to) }"
         >
           <component :is="item.icon" class="mr-3 h-5 w-5" />
           <span>{{ item.label }}</span>
@@ -19,17 +21,21 @@
     </aside>
     <div class="flex min-h-screen flex-1 flex-col">
       <header class="sticky top-0 z-10 flex items-center justify-between border-b border-slate-200 bg-white px-4 py-4 shadow-sm">
-        <button class="lg:hidden inline-flex items-center rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700">
+        <button class="menu-trigger lg:hidden">
           Menü
         </button>
-        <div class="flex flex-col">
-          <span class="text-base font-semibold text-slate-900">Dashboard</span>
-          <RouterView name="breadcrumbs" />
+        <div class="flex items-center gap-4">
+          <RouterLink to="/" aria-label="Startseite" class="app-logo">
+            <img src="/logo.svg" alt="" />
+          </RouterLink>
+          <div class="flex flex-col">
+            <span class="text-base font-semibold text-slate-900">Dashboard</span>
+            <div class="text-muted">
+              <RouterView name="breadcrumbs" />
+            </div>
+          </div>
         </div>
-        <button
-          class="inline-flex items-center rounded-lg bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-700"
-          @click="$emit('logout')"
-        >
+        <button class="btn-primary" @click="$emit('logout')">
           Abmelden
         </button>
       </header>

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -67,6 +67,116 @@ body {
   color: var(--color-text-secondary);
 }
 
+.app-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  border-radius: 9999px;
+  transition: background-color 0.2s ease;
+}
+
+.app-logo img {
+  height: 2rem;
+  width: auto;
+}
+
+.app-logo:hover,
+.app-logo:focus-visible {
+  background-color: var(--color-brand-soft);
+  outline: none;
+}
+
+.app-sidebar {
+  width: 18rem;
+  background: linear-gradient(180deg, var(--color-surface) 0%, #f0f4fb 100%);
+  border-right: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  display: none;
+  box-shadow: 20px 0 45px -24px rgba(21, 32, 54, 0.35);
+}
+
+@media (min-width: 1024px) {
+  .app-sidebar {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.app-sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem 1.25rem;
+}
+
+.app-sidebar__nav {
+  display: flex;
+  flex: 1 1 0%;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1.5rem 1rem;
+}
+
+.app-nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.75rem;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+  font-weight: 500;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-nav-link svg {
+  height: 1.25rem;
+  width: 1.25rem;
+  color: currentColor;
+}
+
+.app-nav-link:hover,
+.app-nav-link:focus-visible {
+  background-color: var(--color-brand-soft);
+  color: var(--color-text-primary);
+  outline: none;
+  box-shadow: 0 0 0 4px var(--color-focus-ring);
+}
+
+.app-nav-link.is-active {
+  background: linear-gradient(135deg, var(--color-brand) 0%, var(--color-brand-strong) 100%);
+  color: var(--color-on-brand);
+  box-shadow: 0 10px 20px -12px rgba(44, 103, 170, 0.8);
+}
+
+.app-nav-link.is-active:hover,
+.app-nav-link.is-active:focus-visible {
+  color: var(--color-on-brand);
+}
+
+.menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
+  font-weight: 600;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.menu-trigger:hover,
+.menu-trigger:focus-visible {
+  border-color: var(--color-brand);
+  background-color: var(--color-brand-soft);
+  color: var(--color-text-primary);
+  outline: none;
+  box-shadow: 0 0 0 4px var(--color-focus-ring);
+}
+
 .app-header {
   background-color: var(--color-brand);
   color: var(--color-on-brand);


### PR DESCRIPTION
## Summary
- add primary logo links to sidebar and header that point to /logo.svg
- restyle navigation, menu trigger, and logout button with the new design token utility classes
- wrap breadcrumb outlet in a muted text container to match the secondary typography

## Testing
- npm run build *(fails: vite build exits with stack trace in dep-D_zLpgQd.js)*

------
https://chatgpt.com/codex/tasks/task_e_690c6b287a148333bf71512fd5f14fa1