### PR TITLE
Fix Vite build by using root favicon paths

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Umsatz Anonymizer</title>
     <meta name="backend-base-url" content="" />
-    <link rel="icon" type="image/svg+xml" href="%VITE_BASE_URL%favicon.svg" />
-    <link rel="icon" type="image/png" href="%VITE_BASE_URL%favicon.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="theme-color" content="#4F46E5" />
     <script type="module">
       const meta = document.querySelector('meta[name="backend-base-url"]');


### PR DESCRIPTION
## Summary
- point favicon links in the frontend HTML template to root-relative paths so they no longer rely on undefined %VITE_BASE_URL% placeholders
- ensure the HTML template can be processed by Vite without URI decoding errors during the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690c6da0d0808333bc0371970721757a