### PR TITLE
Improve import progress dialog messaging

### DIFF
--- a/frontend/src/components/ImportProgressDialog.vue
+++ b/frontend/src/components/ImportProgressDialog.vue
@@ -2,8 +2,11 @@
   <transition enter-active-class="transition duration-200" enter-from-class="opacity-0" leave-active-class="transition duration-150" leave-to-class="opacity-0">
     <div v-if="visible" class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-4">
       <div class="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl">
-        <h3 class="text-lg font-semibold text-slate-900">Import läuft</h3>
-        <p class="mt-2 text-sm text-slate-600">{{ message }}</p>
+        <h3 class="text-lg font-semibold text-slate-900">{{ title }}</h3>
+        <p v-if="message" class="mt-2 text-sm text-slate-600">{{ message }}</p>
+        <p v-if="bankName" class="mt-2 text-sm text-slate-500">
+          Bank: <span class="font-medium text-slate-700">{{ bankName }}</span>
+        </p>
         <div class="mt-6">
           <div class="h-2 rounded-full bg-slate-200">
             <div class="h-2 rounded-full bg-indigo-500 transition-all" :style="{ width: `${progress}%` }"></div>
@@ -31,13 +34,17 @@ const emit = defineEmits<{ (event: "close"): void }>();
 withDefaults(
   defineProps<{
     visible: boolean;
+    title?: string;
     progress?: number;
     message?: string;
+    bankName?: string;
     closable?: boolean;
   }>(),
   {
+    title: "Importstatus",
     progress: 0,
     message: "Die CSV-Datei wird verarbeitet…",
+    bankName: "",
     closable: false,
   },
 );


### PR DESCRIPTION
## Summary
- allow the import progress dialog to display custom titles, messages, and detected bank information
- pass detected bank context from the import view and adjust dialog content for running, success, and error states
- show import results or errors directly within the modal for clearer feedback

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243b109b308333a8ac160f40288605)