### PR TITLE
Improve import modal UX and layout

### DIFF
--- a/frontend/src/components/ImportProgressDialog.vue
+++ b/frontend/src/components/ImportProgressDialog.vue
@@ -1,6 +1,10 @@
 <template>
   <transition enter-active-class="transition duration-200" enter-from-class="opacity-0" leave-active-class="transition duration-150" leave-to-class="opacity-0">
-    <div v-if="visible" class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-4">
+    <div
+      v-if="visible"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/60 px-4"
+      @click.self="closable && emit('close')"
+    >
       <div class="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl">
         <h3 class="text-lg font-semibold text-slate-900">{{ title }}</h3>
         <p v-if="message" class="mt-2 text-sm text-slate-600">{{ message }}</p>


### PR DESCRIPTION
## Summary
- keep the import action inside the CSV card so the page stays above the fold and the mapping form stays hidden
- allow the progress modal backdrop to be dismissed when closable and auto-hide after successful imports for better navigation

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243a04a24483339533ce846169dc0f)