### PR TITLE
Stop auto-hiding import progress dialog on success

### DIFF
--- a/frontend/src/views/ImportView.vue
+++ b/frontend/src/views/ImportView.vue
@@ -272,16 +272,6 @@ watch(
   },
 );
 
-watch(importStatus, (status) => {
-  if (status === "success") {
-    window.setTimeout(() => {
-      if (importStatus.value === "success") {
-        showProgress.value = false;
-      }
-    }, 1500);
-  }
-});
-
 async function handleFileSelected(file: File): Promise<void> {
   await importStore.loadFile(file);
   mapping.value = importStore.mapping;


### PR DESCRIPTION
## Summary
- remove the automatic timeout that hid the import progress dialog after successful import
- rely on the explicit close handler to dismiss the dialog

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69249fc70f4c8333b7ef43b2f2e52b23)