### PR TITLE
Update import summary with append results

### DIFF
--- a/frontend/src/services/storageService.ts
+++ b/frontend/src/services/storageService.ts
@@ -17,6 +17,7 @@ import {
   saveDisplaySettings,
   saveMaskedTransactions,
   saveTransactions,
+  type AppendTransactionsResult,
 } from "../storage";
 import type {
   AnonRule,
@@ -85,12 +86,13 @@ export async function importRulesFromFile(raw: unknown): Promise<AnonRule[] | nu
 
 export async function appendImportedTransactions(
   entries: UnifiedTx[],
-  options: {
+  _options: {
     bankName: string;
     bookingAccount: string;
   },
-): Promise<void> {
-  await appendTransactions(entries, options.bankName, options.bookingAccount);
+): Promise<AppendTransactionsResult> {
+  const result = await appendTransactions(entries);
+  return result;
 }
 
 export async function fetchTransactionImportHistory(): Promise<TransactionImportSummary[]> {
@@ -111,4 +113,5 @@ export type {
   DisplaySettings,
   TransactionImportSummary,
   UnifiedTx,
+  AppendTransactionsResult,
 };

--- a/frontend/src/stores/transactions.test.ts
+++ b/frontend/src/stores/transactions.test.ts
@@ -76,14 +76,18 @@ describe("transactions store", () => {
 
     storageServiceMocks.getTransactions.mockReturnValue(importedEntries);
     storageServiceMocks.getTransactionImports.mockReturnValue(importedHistory);
-    storageServiceMocks.appendImportedTransactions.mockResolvedValue(undefined);
+    storageServiceMocks.appendImportedTransactions.mockResolvedValue({
+      transactions: importedEntries,
+      addedCount: importedEntries.length,
+      skippedDuplicates: 0,
+    });
 
     const store = useTransactionsStore();
     store.setMaskedTransactions(existingMasked);
     store.anonymized = [...existingMasked];
     store.anonymizationWarnings = ["warning"];
 
-    await store.appendImported(importedEntries, { bankName: "Test Bank", bookingAccount: "0001" });
+    const result = await store.appendImported(importedEntries, { bankName: "Test Bank", bookingAccount: "0001" });
 
     expect(storageServiceMocks.appendImportedTransactions).toHaveBeenCalledWith(importedEntries, {
       bankName: "Test Bank",
@@ -95,6 +99,11 @@ describe("transactions store", () => {
     expect(store.anonymizationWarnings).toEqual([]);
     expect(store.maskedTransactions).toEqual([]);
     expect(storageServiceMocks.storeMaskedTransactions).toHaveBeenCalledWith([]);
+    expect(result).toEqual({
+      transactions: importedEntries,
+      addedCount: importedEntries.length,
+      skippedDuplicates: 0,
+    });
   });
 });
 

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -12,6 +12,7 @@ import {
   storeTransactions,
   type TransactionImportSummary,
   type UnifiedTx,
+  type AppendTransactionsResult,
 } from "../services/storageService";
 
 interface TransactionsState {
@@ -118,16 +119,17 @@ export const useTransactionsStore = defineStore("transactions", {
     async appendImported(
       entries: UnifiedTx[],
       options: { bankName: string; bookingAccount: string },
-    ): Promise<void> {
+    ): Promise<AppendTransactionsResult> {
       this.saving = true;
       this.error = null;
       try {
-        await appendImportedTransactions(entries, options);
+        const result = await appendImportedTransactions(entries, options);
         this.transactions = [...getTransactions()];
         this.history = [...getTransactionImports()];
         this.clearAnonymization();
         this.setMaskedTransactions([]);
         await storeMaskedTransactions([]);
+        return result;
       } catch (error) {
         this.error = error instanceof Error ? error.message : "Import konnte nicht gespeichert werden";
         throw error;

--- a/frontend/src/views/ImportView.vue
+++ b/frontend/src/views/ImportView.vue
@@ -302,12 +302,24 @@ async function startImport(): Promise<void> {
     if (!transactions || transactions.length === 0) {
       throw new Error("Es wurden keine Transaktionen erkannt. Bitte prüfen Sie CSV-Datei und Mapping.");
     }
-    await transactionsStore.appendImported(transactions, {
+    const result = await transactionsStore.appendImported(transactions, {
       bankName: importStore.bankName,
       bookingAccount: importStore.bookingAccount,
     });
     progress.value = 100;
-    importSummary.value = `${transactions.length} Transaktionen importiert.`;
+    const importedText =
+      result.addedCount === 1
+        ? "1 Umsatz importiert"
+        : `${result.addedCount} Umsätze importiert`;
+    const duplicatesText =
+      result.skippedDuplicates === 1
+        ? "1 Doppelgänger erkannt"
+        : `${result.skippedDuplicates} Doppelgänger erkannt`;
+    if (result.skippedDuplicates > 0) {
+      importSummary.value = `${duplicatesText}, ${importedText}.`;
+    } else {
+      importSummary.value = `${importedText}.`;
+    }
     importStatus.value = "success";
   } catch (error) {
     console.error("Import failed", error);


### PR DESCRIPTION
## Summary
- return append transaction results from the storage layer and surface them through the transactions store
- base import dialog summary text on added transactions and detected duplicates
- update transactions store tests to reflect returned append metadata

## Testing
- npm test -- --runInBand *(fails: backend tests missing dev dependency `supertest`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a1c219f48333ae8c5a69698df381)