### PR TITLE
Handle bank detection without default selection

### DIFF
--- a/frontend/src/stores/import.ts
+++ b/frontend/src/stores/import.ts
@@ -80,7 +80,12 @@ export const useImportStore = defineStore("import", {
         return;
       }
       const preferredIndex = candidates.findIndex((candidate) => candidate.passed);
-      this.selectDetectedBank(preferredIndex >= 0 ? preferredIndex : 0);
+      if (preferredIndex === -1) {
+        this.selectedDetectedBankIndex = null;
+        this.detectedBank = null;
+        return;
+      }
+      this.selectDetectedBank(preferredIndex);
     },
     selectDetectedBank(index: number | null): void {
       if (index === null || index < 0 || index >= this.detectedBanks.length) {

--- a/frontend/src/stores/import.ts
+++ b/frontend/src/stores/import.ts
@@ -77,12 +77,14 @@ export const useImportStore = defineStore("import", {
       if (candidates.length === 0) {
         this.selectedDetectedBankIndex = null;
         this.detectedBank = null;
+        this.bankName = "";
         return;
       }
       const preferredIndex = candidates.findIndex((candidate) => candidate.passed);
       if (preferredIndex === -1) {
         this.selectedDetectedBankIndex = null;
         this.detectedBank = null;
+        this.bankName = "";
         return;
       }
       this.selectDetectedBank(preferredIndex);

--- a/frontend/src/views/ImportView.vue
+++ b/frontend/src/views/ImportView.vue
@@ -34,6 +34,7 @@
                 class="mt-2 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 aria-describedby="bank-name-hint"
               >
+                <option value="" disabled>Bitte Bank auswählen</option>
                 <option v-for="(candidate, index) in importStore.detectedBanks" :key="`${candidate.mapping.bank_name}-${index}`" :value="`${index}`">
                   {{ candidate.mapping.bank_name }}
                 </option>


### PR DESCRIPTION
## Summary
- avoid automatically selecting detected bank candidates unless they passed detection
- show placeholder option when detected banks are present so none is preselected when no candidate passed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a50c90e083338ed52a70f87f4233)