### PR TITLE
Add configurable import progress action button

### DIFF
--- a/frontend/src/components/ImportProgressDialog.vue
+++ b/frontend/src/components/ImportProgressDialog.vue
@@ -22,9 +22,9 @@
           <button
             type="button"
             class="inline-flex items-center rounded-lg bg-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-300"
-            @click="emit('close')"
+            @click="emit('action')"
           >
-            Schließen
+            {{ actionLabel }}
           </button>
         </div>
       </div>
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-const emit = defineEmits<{ (event: "close"): void }>();
+const emit = defineEmits<{ (event: "close"): void; (event: "action"): void }>();
 
 withDefaults(
   defineProps<{
@@ -43,6 +43,7 @@ withDefaults(
     message?: string;
     bankName?: string;
     closable?: boolean;
+    actionLabel?: string;
   }>(),
   {
     title: "Importstatus",
@@ -50,6 +51,7 @@ withDefaults(
     message: "Die CSV-Datei wird verarbeitet…",
     bankName: "",
     closable: false,
+    actionLabel: "Schließen",
   },
 );
 </script>

--- a/frontend/src/views/ImportView.vue
+++ b/frontend/src/views/ImportView.vue
@@ -122,13 +122,16 @@
       :message="dialogMessage"
       :bank-name="detectedBankName"
       :closable="dialogClosable"
+      :action-label="progressButtonLabel"
       @close="handleProgressClose"
+      @action="handleProgressAction"
     />
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from "vue";
+import { useRouter } from "vue-router";
 import FileUpload from "../components/FileUpload.vue";
 import ImportProgressDialog from "../components/ImportProgressDialog.vue";
 import TransactionImportsPanel from "../components/TransactionImportsPanel.vue";
@@ -142,6 +145,7 @@ const importStore = useImportStore();
 const bankMappingsStore = useBankMappingsStore();
 const displaySettingsStore = useDisplaySettingsStore();
 const transactionsStore = useTransactionsStore();
+const router = useRouter();
 
 const showProgress = ref(false);
 const progress = ref(0);
@@ -176,6 +180,13 @@ const dialogMessage = computed(() => {
     return importSummary.value || "Import fehlgeschlagen. Bitte prüfen Sie die Konsole für Details.";
   }
   return "";
+});
+
+const progressButtonLabel = computed(() => {
+  if (importStatus.value === "success") {
+    return "Weiter zu Transaktionen";
+  }
+  return "Schließen";
 });
 
 const mapping = reactive<{ value: MappingSelection | null }>({ value: importStore.mapping });
@@ -334,6 +345,13 @@ async function startImport(): Promise<void> {
   } finally {
     dialogClosable.value = true;
   }
+}
+
+async function handleProgressAction(): Promise<void> {
+  if (importStatus.value === "success") {
+    await router.push({ name: "transactions" });
+  }
+  handleProgressClose();
 }
 
 function handleProgressClose(): void {


### PR DESCRIPTION
## Summary
- add configurable action button label and event to the import progress dialog
- adjust the import view to control the button text by status and navigate to transactions after success

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a92766748333be7c2423dbd6b3a6)