### PR TITLE
Add reusable dialog for creating anonymization rules

### DIFF
--- a/frontend/src/components/RuleCreationDialog.vue
+++ b/frontend/src/components/RuleCreationDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <Teleport to="body">
     <div
-      v-if="open && selection"
+      v-if="open"
       class="fixed inset-0 z-40 flex items-center justify-center bg-slate-900/50 px-4 py-8"
       @click.self="onClose"
     >
@@ -17,7 +17,9 @@
         <div class="flex items-start justify-between border-b border-slate-200 px-6 py-4">
           <div>
             <h2 :id="titleId" class="text-lg font-semibold text-slate-900">Regel aus Auswahl erstellen</h2>
-            <p class="text-sm text-slate-600">Nutzen Sie die Auswahl als Basis für eine neue Regex-Regel.</p>
+            <p class="text-sm text-slate-600">
+              Nutzen Sie einen ausgewählten Originalwert, um eine Regex- oder Maskierungsregel anzulegen.
+            </p>
           </div>
           <button
             type="button"
@@ -30,11 +32,17 @@
         </div>
         <form class="space-y-6 px-6 py-5" @submit.prevent="onSubmit">
           <div class="grid gap-4 md:grid-cols-2">
-            <div class="rounded-lg bg-slate-50 p-4 text-sm text-slate-700">
-              <p class="font-semibold text-slate-900">Ausgewählter Text</p>
-              <p class="break-words text-slate-700">{{ selection.selectedText }}</p>
-              <p class="mt-3 text-xs text-slate-500">Feld: {{ selectionFieldLabel }}</p>
-              <p v-if="selection.bookingHash" class="text-xs text-slate-500">Hash: {{ selection.bookingHash }}</p>
+            <div class="space-y-3 text-sm text-slate-700">
+              <label class="block text-xs font-medium text-slate-600">Originalwert</label>
+              <textarea
+                v-model="originalValue"
+                rows="3"
+                class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                placeholder="Markierter Text oder manuelle Eingabe"
+              ></textarea>
+              <p class="text-xs text-slate-500">Auswahl aus der Tabelle oder manuell eingeben.</p>
+              <p v-if="selectionFieldLabel" class="text-xs text-slate-500">Feld: {{ selectionFieldLabel }}</p>
+              <p v-if="selection?.bookingHash" class="text-xs text-slate-500">Hash: {{ selection.bookingHash }}</p>
             </div>
             <div class="space-y-3 text-sm text-slate-700">
               <label class="block text-xs font-medium text-slate-600">Regel-ID</label>
@@ -49,6 +57,37 @@
           </div>
 
           <div class="grid gap-4 md:grid-cols-2">
+            <div class="space-y-2">
+              <label class="block text-xs font-medium text-slate-600">Regeltyp</label>
+              <select
+                v-model="ruleType"
+                class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              >
+                <option value="regex">Regex</option>
+                <option value="mask">Maskierung</option>
+              </select>
+            </div>
+            <div>
+              <label class="block text-xs font-medium text-slate-600">Felder</label>
+              <div class="mt-2 grid gap-2 sm:grid-cols-2">
+                <label
+                  v-for="option in fieldOptions"
+                  :key="option.value"
+                  class="flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700"
+                >
+                  <input
+                    v-model="selectedFields"
+                    type="checkbox"
+                    :value="option.value"
+                    class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                  />
+                  {{ option.label }}
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="ruleType === 'regex'" class="grid gap-4 md:grid-cols-2">
             <div>
               <label class="block text-xs font-medium text-slate-600">Pattern</label>
               <input
@@ -80,22 +119,49 @@
             </div>
           </div>
 
-          <div>
-            <label class="block text-xs font-medium text-slate-600">Felder</label>
-            <div class="mt-2 grid gap-2 sm:grid-cols-2">
-              <label
-                v-for="option in fieldOptions"
-                :key="option.value"
-                class="flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700"
+          <div v-else class="grid gap-4 md:grid-cols-2">
+            <div>
+              <label class="block text-xs font-medium text-slate-600">Maskierungsstrategie</label>
+              <select
+                v-model="maskStrategy"
+                class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
               >
+                <option value="full">Komplett maskieren</option>
+                <option value="keepFirstLast">Erstes/letztes Zeichen behalten</option>
+                <option value="partialPercent">Prozentual maskieren</option>
+              </select>
+            </div>
+            <div class="grid gap-3 md:grid-cols-2">
+              <div>
+                <label class="block text-xs font-medium text-slate-600">Maskierungszeichen</label>
                 <input
-                  v-model="selectedFields"
-                  type="checkbox"
-                  :value="option.value"
-                  class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                  v-model="maskChar"
+                  type="text"
+                  maxlength="1"
+                  class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  placeholder="•"
                 />
-                {{ option.label }}
-              </label>
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-slate-600">Minimale Länge</label>
+                <input
+                  v-model.number="minLen"
+                  type="number"
+                  min="0"
+                  class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <div class="md:col-span-2">
+                <label class="block text-xs font-medium text-slate-600">Maskierungsanteil (0-1)</label>
+                <input
+                  v-model.number="maskPercent"
+                  type="number"
+                  min="0"
+                  max="1"
+                  step="0.05"
+                  class="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
             </div>
           </div>
 
@@ -134,16 +200,23 @@ export interface RuleCreationSelection {
   bookingHash?: string;
 }
 
-const props = defineProps<{ open: boolean; selection: RuleCreationSelection | null }>();
+const props = defineProps<{ open: boolean; selection?: RuleCreationSelection | null; defaultType?: "regex" | "mask" }>();
 const emit = defineEmits<{ (e: "close"): void; (e: "created", value: AnonRule): void }>();
 
 const rulesStore = useAnonymizationRulesStore();
 
 const ruleId = ref("");
+const ruleType = ref<"regex" | "mask">("regex");
+const originalValue = ref("");
 const pattern = ref("");
 const replacement = ref("***");
 const flags = ref("gi");
 const selectedFields = ref<(keyof UnifiedTx)[]>([]);
+const lastAutoPattern = ref("");
+const maskStrategy = ref<"full" | "keepFirstLast" | "partialPercent">("partialPercent");
+const maskChar = ref("•");
+const minLen = ref(4);
+const maskPercent = ref(0.5);
 const saveError = ref<string | null>(null);
 const saving = ref(false);
 const dialogRef = ref<HTMLDivElement | null>(null);
@@ -166,6 +239,22 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&");
 }
 
+function createRuleIdWithFallback(): string {
+  const prefix = ruleType.value === "mask" ? "mask" : "regex";
+  return `${prefix}-${Date.now().toString(36)}`;
+}
+
+function updatePatternFromOriginal(): void {
+  if (ruleType.value !== "regex") {
+    return;
+  }
+  const escaped = escapeRegExp(originalValue.value);
+  if (!pattern.value || pattern.value === lastAutoPattern.value) {
+    pattern.value = escaped;
+  }
+  lastAutoPattern.value = escaped;
+}
+
 function createDefaultId(selection: RuleCreationSelection): string {
   const snippet = selection.selectedText.trim().slice(0, 24).replace(/\s+/g, "-");
   const sanitizedSnippet = snippet.replace(/[^a-zA-Z0-9_-]/g, "").toLowerCase();
@@ -174,21 +263,26 @@ function createDefaultId(selection: RuleCreationSelection): string {
 }
 
 function resetForm(): void {
-  if (!props.selection) {
-    return;
-  }
-  ruleId.value = createDefaultId(props.selection);
-  pattern.value = escapeRegExp(props.selection.selectedText);
+  const selection = props.selection;
+  ruleType.value = props.defaultType ?? "regex";
+  ruleId.value = selection ? createDefaultId(selection) : "";
+  originalValue.value = selection?.selectedText ?? "";
+  pattern.value = escapeRegExp(originalValue.value);
+  lastAutoPattern.value = pattern.value;
   replacement.value = "***";
   flags.value = "gi";
-  selectedFields.value = [props.selection.field];
+  selectedFields.value = [selection?.field ?? "booking_text"];
+  maskStrategy.value = "partialPercent";
+  maskChar.value = "•";
+  minLen.value = Math.max(selection?.selectedText.length ?? 0, 4);
+  maskPercent.value = 0.5;
   saveError.value = null;
 }
 
 watch(
   () => props.open,
   (isOpen) => {
-    if (isOpen && props.selection) {
+    if (isOpen) {
       resetForm();
       nextTick(() => {
         dialogRef.value?.focus();
@@ -197,22 +291,61 @@ watch(
   },
 );
 
+watch(
+  () => originalValue.value,
+  () => {
+    updatePatternFromOriginal();
+  },
+);
+
+watch(
+  () => ruleType.value,
+  (type) => {
+    if (type === "regex") {
+      updatePatternFromOriginal();
+    }
+  },
+);
+
 async function onSubmit(): Promise<void> {
-  if (!props.selection) {
-    return;
-  }
   if (selectedFields.value.length === 0) {
     saveError.value = "Bitte mindestens ein Feld auswählen.";
     return;
   }
 
+  if (!originalValue.value.trim() && ruleType.value === "regex") {
+    saveError.value = "Bitte einen Originalwert eingeben.";
+    return;
+  }
+
+  if (ruleType.value === "regex" && !pattern.value.trim()) {
+    saveError.value = "Bitte ein Pattern hinterlegen.";
+    return;
+  }
+
+  if (ruleType.value === "mask" && !maskChar.value) {
+    saveError.value = "Bitte ein Maskierungszeichen angeben.";
+    return;
+  }
+
   const newRule: AnonRule = {
-    id: ruleId.value.trim() || createDefaultId(props.selection),
+    id:
+      ruleId.value.trim() ||
+      (props.selection ? createDefaultId(props.selection) : createRuleIdWithFallback()),
     fields: [...selectedFields.value],
-    type: "regex",
-    pattern: pattern.value,
-    flags: flags.value.trim() || undefined,
-    replacement: replacement.value,
+    type: ruleType.value,
+    ...(ruleType.value === "regex"
+      ? {
+          pattern: pattern.value,
+          flags: flags.value.trim() || undefined,
+          replacement: replacement.value,
+        }
+      : {
+          maskStrategy: maskStrategy.value,
+          maskChar: maskChar.value,
+          minLen: minLen.value,
+          maskPercent: maskPercent.value,
+        }),
     enabled: true,
   };
 

--- a/frontend/src/components/RuleCreationDialog.vue
+++ b/frontend/src/components/RuleCreationDialog.vue
@@ -200,7 +200,12 @@ export interface RuleCreationSelection {
   bookingHash?: string;
 }
 
-const props = defineProps<{ open: boolean; selection?: RuleCreationSelection | null; defaultType?: "regex" | "mask" }>();
+const props = defineProps<{
+  open: boolean;
+  selection?: RuleCreationSelection | null;
+  defaultType?: "regex" | "mask";
+  currentRules?: AnonRule[];
+}>();
 const emit = defineEmits<{ (e: "close"): void; (e: "created", value: AnonRule): void }>();
 
 const rulesStore = useAnonymizationRulesStore();
@@ -353,7 +358,8 @@ async function onSubmit(): Promise<void> {
   saveError.value = null;
   try {
     await rulesStore.initialize();
-    await rulesStore.save([...rulesStore.rules, newRule]);
+    const baseRules = props.currentRules ?? rulesStore.rules;
+    await rulesStore.save([...baseRules, newRule]);
     emit("created", newRule);
     onClose();
   } catch (error) {

--- a/frontend/src/views/SettingsAnonymizationRulesView.vue
+++ b/frontend/src/views/SettingsAnonymizationRulesView.vue
@@ -8,14 +8,14 @@
           <button
             type="button"
             class="inline-flex items-center rounded-lg border border-indigo-200 px-3 py-2 text-xs font-semibold text-indigo-600 hover:bg-indigo-50"
-            @click="addRegexRule"
+            @click="openDialog('regex')"
           >
             Regex-Regel hinzufügen
           </button>
           <button
             type="button"
             class="inline-flex items-center rounded-lg border border-indigo-200 px-3 py-2 text-xs font-semibold text-indigo-600 hover:bg-indigo-50"
-            @click="addMaskRule"
+            @click="openDialog('mask')"
           >
             Maskierungsregel hinzufügen
           </button>
@@ -169,12 +169,20 @@
       <p v-if="rulesStore.error" class="mt-2 text-sm font-medium text-rose-600">{{ rulesStore.error }}</p>
     </section>
   </div>
+  <RuleCreationDialog
+    :open="ruleDialogOpen"
+    :selection="dialogSelection"
+    :default-type="dialogType"
+    @close="onDialogClose"
+    @created="onRuleCreated"
+  />
 </template>
 
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from "@headlessui/vue";
 import { ChevronDownIcon } from "@heroicons/vue/24/outline";
 import { reactive, ref, watchEffect } from "vue";
+import RuleCreationDialog, { type RuleCreationSelection } from "../components/RuleCreationDialog.vue";
 import { useAnonymizationRulesStore } from "../stores/anonymizationRules";
 import type { AnonRule } from "../services/storageService";
 
@@ -182,6 +190,9 @@ const rulesStore = useAnonymizationRulesStore();
 const rules = reactive<AnonRule[]>([]);
 const statusMessage = ref("");
 const importInput = ref<HTMLInputElement | null>(null);
+const ruleDialogOpen = ref(false);
+const dialogSelection = ref<RuleCreationSelection | null>(null);
+const dialogType = ref<"regex" | "mask">("regex");
 
 function cloneRule(rule: AnonRule): AnonRule {
   return JSON.parse(JSON.stringify(rule)) as AnonRule;
@@ -191,41 +202,22 @@ watchEffect(() => {
   rules.splice(0, rules.length, ...rulesStore.rules.map((rule) => cloneRule(rule)));
 });
 
-function createRuleId(prefix: string): string {
-  const base = `${prefix}-${Date.now().toString(36)}`;
-  let id = base;
-  let counter = 1;
-  const existingIds = new Set(rules.map((rule) => rule.id));
-  while (existingIds.has(id)) {
-    id = `${base}-${counter}`;
-    counter += 1;
-  }
-  return id;
+void rulesStore.initialize();
+
+function openDialog(type: "regex" | "mask"): void {
+  dialogType.value = type;
+  dialogSelection.value = { selectedText: "", field: "booking_text" };
+  ruleDialogOpen.value = true;
 }
 
-function addRegexRule(): void {
-  rules.push({
-    id: createRuleId("regex"),
-    type: "regex",
-    fields: ["booking_text"],
-    pattern: "",
-    flags: "gi",
-    replacement: "***",
-    enabled: true,
-  });
+function onDialogClose(): void {
+  ruleDialogOpen.value = false;
+  dialogSelection.value = null;
 }
 
-function addMaskRule(): void {
-  rules.push({
-    id: createRuleId("mask"),
-    type: "mask",
-    fields: ["booking_text"],
-    maskStrategy: "partialPercent",
-    maskChar: "•",
-    minLen: 4,
-    maskPercent: 0.5,
-    enabled: true,
-  });
+function onRuleCreated(rule: AnonRule): void {
+  statusMessage.value = `Regel "${rule.id}" gespeichert.`;
+  onDialogClose();
 }
 
 function removeRule(id: string): void {

--- a/frontend/src/views/SettingsAnonymizationRulesView.vue
+++ b/frontend/src/views/SettingsAnonymizationRulesView.vue
@@ -173,6 +173,7 @@
     :open="ruleDialogOpen"
     :selection="dialogSelection"
     :default-type="dialogType"
+    :current-rules="rules"
     @close="onDialogClose"
     @created="onRuleCreated"
   />


### PR DESCRIPTION
## Summary
- extend the rule creation dialog to accept manual input, choose regex or masking options, and validate required fields
- integrate the dialog into the anonymization settings view so new rules are created via the shared flow and saved to the store
- keep rule creation hooked into existing transaction context usage while initializing the rules store when needed

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c432d854833391e0555e66ce5c23)