### PR TITLE
Store anonymization rules in token settings

### DIFF
--- a/backend/db/index.js
+++ b/backend/db/index.js
@@ -1,6 +1,17 @@
 const { Pool } = require("pg");
 
 const MASKED_SNAPSHOT_CATEGORY = "__masked_snapshot__";
+const ALLOWED_TRANSACTION_KEYS = new Set([
+  "bank_name",
+  "booking_date",
+  "booking_date_raw",
+  "booking_date_iso",
+  "booking_text",
+  "booking_type",
+  "booking_amount",
+  "booking_hash",
+  "booking_account",
+]);
 const ANON_RULES_KEY = "anonymization_rules_v1";
 const DEFAULT_ANON_RULES = {
   version: 1,

--- a/frontend/src/services/storageService.ts
+++ b/frontend/src/services/storageService.ts
@@ -68,7 +68,7 @@ export async function storeDisplaySettings(settings: DisplaySettings): Promise<v
 }
 
 export async function storeAnonymizationRules(rules: AnonRule[]): Promise<void> {
-  saveAnonymizationRules(rules);
+  await saveAnonymizationRules(rules);
 }
 
 export async function storeBankMapping(mapping: BankMapping): Promise<BankMapping> {
@@ -80,7 +80,7 @@ export async function importBankMappingsFromFile(raw: unknown): Promise<BankMapp
 }
 
 export async function importRulesFromFile(raw: unknown): Promise<AnonRule[] | null> {
-  const result = importAnonymizationRules(raw);
+  const result = await importAnonymizationRules(raw);
   return result?.rules ?? null;
 }
 

--- a/frontend/src/stores/anonymizationRules.ts
+++ b/frontend/src/stores/anonymizationRules.ts
@@ -46,7 +46,9 @@ export const useAnonymizationRulesStore = defineStore("anonymizationRules", {
       this.error = null;
       try {
         await storeAnonymizationRules(rules);
-        this.rules = [...rules];
+        const { rules: savedRules, version } = getAnonymizationRules();
+        this.rules = [...savedRules];
+        this.version = version;
       } catch (error) {
         this.error = error instanceof Error ? error.message : "Regeln konnten nicht gespeichert werden";
         throw error;
@@ -60,7 +62,9 @@ export const useAnonymizationRulesStore = defineStore("anonymizationRules", {
       try {
         const rules = await importRulesFromFile(raw);
         if (rules) {
-          this.rules = rules;
+          const { rules: savedRules, version } = getAnonymizationRules();
+          this.rules = savedRules;
+          this.version = version;
         }
         return rules;
       } catch (error) {


### PR DESCRIPTION
## Summary
- persist anonymization rules alongside display settings in the token settings JSON instead of a separate table
- expose anonymization rule CRUD operations through settings-aware DB helpers and keep defaults when none are stored
- align frontend storage with settings-based rule persistence and versioning

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925cc2e051c83338651780d79946856)