### PR TITLE
Define allowed transaction keys in frontend storage

### DIFF
--- a/frontend/src/storage.ts
+++ b/frontend/src/storage.ts
@@ -92,6 +92,17 @@ const TRANSACTIONS_MASKED_KEY = "transactions_unified_masked_v1";
 const ANON_RULES_KEY = "anonymization_rules_v1";
 const DISPLAY_SETTINGS_KEY = "display_settings_v1";
 const CURRENT_RULE_VERSION = 1;
+const ALLOWED_TRANSACTION_KEYS = new Set<keyof UnifiedTx>([
+  "bank_name",
+  "booking_date",
+  "booking_date_raw",
+  "booking_date_iso",
+  "booking_text",
+  "booking_type",
+  "booking_amount",
+  "booking_account",
+  "booking_hash",
+]);
 const ALLOWED_MASK_STRATEGIES = new Set<string>(["full", "keepFirstLast", "partialPercent"]);
 
 const bankMappingsCache: BankMapping[] = [];


### PR DESCRIPTION
## Summary
- add the missing allowed transaction key set to the frontend storage module
- ensure anonymization rule filtering uses the defined transaction fields

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925df298c78833381d5a6015c1b9521)